### PR TITLE
Determine the visibility based on the original type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,6 @@ A lightweight version of pin-project written with declarative macros.
 [workspace]
 members = ["tests/doc"]
 
-[dependencies]
-
 [dev-dependencies]
 rustversion = "1.0"
 trybuild = "1.0"

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -212,6 +212,26 @@ fn lifetime_project_elided() {
     }
 }
 
+mod visibility {
+    use pin_project_lite::pin_project;
+
+    pin_project! {
+        pub(crate) struct A {
+            pub b: u8,
+        }
+    }
+}
+
+#[test]
+fn visibility() {
+    let mut x = visibility::A { b: 0 };
+    let x = Pin::new(&mut x);
+    let y = x.as_ref().project_ref();
+    let _: &u8 = y.b;
+    let y = x.project();
+    let _: &mut u8 = y.b;
+}
+
 #[test]
 fn trivial_bounds() {
     pin_project! {


### PR DESCRIPTION
The visibility of the projected type and projection method is based on
the original type. However, if the visibility of the original type is
`pub`, the visibility of the projected type and the projection method is
`pub(crate)`.

Based on https://github.com/taiki-e/pin-project/pull/96