### PR TITLE
Support recognizing default generic parameters.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ macro_rules! pin_project {
         pub struct $ident:ident
             $(<
                 $( $lifetime:lifetime ),* $(,)?
-                $( $generics:ident $(: $generics_bound:path)? ),* $(,)?
+                $( $generics:ident $(: $generics_bound:path)? $(= $generics_default:ty)? ),* $(,)?
             >)?
             $(where
                 $($where_clause_ty:ty : $where_clause_bound:path),* $(,)?
@@ -164,7 +164,7 @@ macro_rules! pin_project {
             pub struct $ident
                 $(<
                     $( $lifetime ),*
-                    $( $generics $(: $generics_bound)? ),*
+                    $( $generics $(: $generics_bound)? $(= $generics_default)? ),*
                 >)?
                 $(where
                     $($where_clause_ty : $where_clause_bound),*
@@ -182,7 +182,7 @@ macro_rules! pin_project {
         $vis:vis struct $ident:ident
             $(<
                 $( $lifetime:lifetime ),* $(,)?
-                $( $generics:ident $(: $generics_bound:path)? ),* $(,)?
+                $( $generics:ident $(: $generics_bound:path)? $(= $generics_default:ty)? ),* $(,)?
             >)?
             $(where
                 $($where_clause_ty:ty : $where_clause_bound:path),* $(,)?
@@ -199,7 +199,7 @@ macro_rules! pin_project {
             $vis struct $ident
                 $(<
                     $( $lifetime ),*
-                    $( $generics $(: $generics_bound)? ),*
+                    $( $generics $(: $generics_bound)? $(= $generics_default)? ),*
                 >)?
                 $(where
                     $($where_clause_ty : $where_clause_bound),*
@@ -221,7 +221,7 @@ macro_rules! pin_project {
             $(<
                 $( $lifetime:lifetime ),*
                 // limitation: does not support multiple bounds and ? bounds.
-                $( $generics:ident $(: $generics_bound:path)? ),*
+                $( $generics:ident $(: $generics_bound:path)? $(= $generics_default:ty)? ),*
             >)?
             $(where
                 // limitation: does not support multiple bounds and ? bounds.
@@ -237,7 +237,7 @@ macro_rules! pin_project {
     ) => {
         $(#[$attrs])*
         $vis struct $ident
-            $(< $( $lifetime ,)* $( $generics $(: $generics_bound)? ,)* >)?
+            $(< $( $lifetime ,)* $( $generics $(: $generics_bound)? $(= $generics_default)? ,)* >)?
             $(where
                 $($where_clause_ty: $where_clause_bound),*
             )*

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -124,6 +124,14 @@ fn trait_bounds_on_type_generics() {
     //         field: &'a mut T,
     //     }
     // }
+
+    pin_project! {
+        pub struct Struct6<'a, T: core::fmt::Debug = [u8; 16]> {
+            field: &'a mut T,
+        }
+    }
+
+    let _: Struct6<'_> = Struct6 { field: &mut [0u8; 16] };
 }
 
 #[test]


### PR DESCRIPTION
Make this work:

```rust
pin_project! {
    struct Foo<T = Bar> {
        field: T,
    }
}
```

The default parameter is not applied to the generated `Projection`/`ProjectionRef`/`__Origin` types.