### PR TITLE
Fix compatibility of generated code with forbid(future_incompatible)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@ macro_rules! __pin_project_internal {
             // Ensure that it's impossible to use pin projections on a #[repr(packed)] struct.
             //
             // Taking a reference to a packed field is unsafe, amd appplying
-            // #[deny(safe_packed_borrows)] makes sure that doing this without
+            // #[forbid(safe_packed_borrows)] makes sure that doing this without
             // an 'unsafe' block (which we deliberately do not generate)
             // is a hard error.
             //
@@ -285,7 +285,7 @@ macro_rules! __pin_project_internal {
             // a much nicer error above.
             //
             // See https://github.com/taiki-e/pin-project/pull/34 for more details.
-            #[deny(safe_packed_borrows)]
+            #[forbid(safe_packed_borrows)]
             fn __assert_not_repr_packed <$($impl_generics)*> (this: &$ident <$($ty_generics)*>)
             $(where
                 $($where_clause)*)?

--- a/tests/expand/tests/expand/default-struct.expanded.rs
+++ b/tests/expand/tests/expand/default-struct.expanded.rs
@@ -62,7 +62,7 @@ const _: () = {
     #[allow(clippy::drop_bounds)]
     impl<T: ::pin_project_lite::__private::Drop> MustNotImplDrop for T {}
     impl<T, U> MustNotImplDrop for Struct<T, U> {}
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/expand/tests/expand/pub-struct.expanded.rs
+++ b/tests/expand/tests/expand/pub-struct.expanded.rs
@@ -62,7 +62,7 @@ const _: () = {
     #[allow(clippy::drop_bounds)]
     impl<T: ::pin_project_lite::__private::Drop> MustNotImplDrop for T {}
     impl<T, U> MustNotImplDrop for Struct<T, U> {}
-    #[deny(safe_packed_borrows)]
+    #[forbid(safe_packed_borrows)]
     fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
         let _ = &this.pinned;
         let _ = &this.unpinned;

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -1,4 +1,7 @@
-#![warn(future_incompatible, nonstandard_style, rust_2018_compatibility, rust_2018_idioms, unused)]
+#![warn(nonstandard_style, rust_2018_compatibility, rust_2018_idioms, unused)]
+// Note: This does not guarantee compatibility with `forbid(future_incompatible)` in the future.
+// If rustc adds a new lint, we may not be able to keep this.
+#![forbid(future_incompatible)]
 #![forbid(unsafe_code)]
 #![allow(unknown_lints)] // for old compilers
 #![warn(


### PR DESCRIPTION
Note: This does not guarantee compatibility with `forbid(future_incompatible)` in the future.
If rustc adds a new lint, we may not be able to keep this.

cc https://github.com/taiki-e/pin-project/issues/281