### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,60 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 ## [Unreleased]
 
+## [0.2.0] - 2020-11-13
+
+* [`pin_project!` macro now supports enums.][28]
+
+  To use `pin_project!` on enums, you need to name the projection type
+  returned from the method.
+
+  ```rust
+  use pin_project_lite::pin_project;
+  use std::pin::Pin;
+
+  pin_project! {
+      #[project = EnumProj]
+      enum Enum<T, U> {
+          Variant { #[pin] pinned: T, unpinned: U },
+      }
+  }
+
+  impl<T, U> Enum<T, U> {
+      fn method(self: Pin<&mut Self>) {
+          match self.project() {
+              EnumProj::Variant { pinned, unpinned } => {
+                  let _: Pin<&mut T> = pinned;
+                  let _: &mut U = unpinned;
+              }
+          }
+      }
+  }
+  ```
+
+* [Support naming the projection types.][28]
+
+  By passing an attribute with the same name as the method, you can name the projection type returned from the method:
+
+  ```rust
+  use pin_project_lite::pin_project;
+  use std::pin::Pin;
+
+  pin_project! {
+      #[project = StructProj]
+      struct Struct<T> {
+          #[pin]
+          field: T,
+      }
+  }
+
+  fn func<T>(x: Pin<&mut Struct<T>>) {
+      let StructProj { field } = x.project();
+      let _: Pin<&mut T> = field;
+  }
+  ```
+
+[28]: https://github.com/taiki-e/pin-project-lite/pull/28
+
 ## [0.1.11] - 2020-10-20
 
 * Suppress `clippy::redundant_pub_crate` lint in generated code.
@@ -82,7 +136,8 @@ This project adheres to [Semantic Versioning](https://semver.org).
 
 Initial release
 
-[Unreleased]: https://github.com/taiki-e/pin-project-lite/compare/v0.1.11...HEAD
+[Unreleased]: https://github.com/taiki-e/pin-project-lite/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/taiki-e/pin-project-lite/compare/v0.1.11...v0.2.0
 [0.1.11]: https://github.com/taiki-e/pin-project-lite/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/taiki-e/pin-project-lite/compare/v0.1.9...v0.1.10
 [0.1.9]: https://github.com/taiki-e/pin-project-lite/compare/v0.1.8...v0.1.9

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.2.0"
 authors = ["Taiki Endo <te316e89@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 OR MIT"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pin-project-lite = "0.1"
+pin-project-lite = "0.2"
 ```
 
 The current pin-project-lite requires Rust 1.37 or later.
@@ -110,7 +110,7 @@ pin-project supports this by [`UnsafeUnpin`][unsafe-unpin] and [`!Unpin`][not-un
 
 pin-project supports this.
 
-[`pin_project!`]: https://docs.rs/pin-project-lite/0.1/pin_project_lite/macro.pin_project.html
+[`pin_project!`]: https://docs.rs/pin-project-lite/0.2/pin_project_lite/macro.pin_project.html
 [not-unpin]: https://docs.rs/pin-project/1/pin_project/attr.pin_project.html#unpin
 [pin-project]: https://github.com/taiki-e/pin-project
 [pinned-drop]: https://docs.rs/pin-project/1/pin_project/attr.pin_project.html#pinned_drop

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@
 //! [unsafe-unpin]: https://docs.rs/pin-project/1/pin_project/attr.pin_project.html#unsafeunpin
 
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/pin-project-lite/0.1.11")]
+#![doc(html_root_url = "https://docs.rs/pin-project-lite/0.2.0")]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms, single_use_lifetimes), allow(dead_code))


### PR DESCRIPTION
[Changes](https://github.com/taiki-e/pin-project-lite/blob/2d8bba1905bfc2da22a16c7e40703cd02d141916/CHANGELOG.md#020---2020-11-13)

#28 has made significant changes to the existing parsing and may cause some breakage, so bump minor version.