### PR TITLE
feat: Add project_replace

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,6 @@
         allow(dead_code, unused_variables)
     )
 ))]
-#![warn(unsafe_code)]
 #![warn(future_incompatible, rust_2018_idioms, single_use_lifetimes, unreachable_pub)]
 #![warn(clippy::all, clippy::default_trait_access)]
 
@@ -299,10 +298,47 @@ macro_rules! pin_project {
         $(#[doc $($doc:tt)*])*
         #[project = $proj_mut_ident:ident]
         #[project_ref = $proj_ref_ident:ident]
+        #[project_replace = $proj_replace_ident:ident]
         $($tt:tt)*
     ) => {
         $crate::__pin_project_internal! {
-            [$proj_mut_ident][$proj_ref_ident]
+            [$proj_mut_ident][$proj_ref_ident][$proj_replace_ident]
+            $(#[doc $($doc)*])*
+            $($tt)*
+        }
+    };
+    (
+        $(#[doc $($doc:tt)*])*
+        #[project = $proj_mut_ident:ident]
+        #[project_ref = $proj_ref_ident:ident]
+        $($tt:tt)*
+    ) => {
+        $crate::__pin_project_internal! {
+            [$proj_mut_ident][$proj_ref_ident][]
+            $(#[doc $($doc)*])*
+            $($tt)*
+        }
+    };
+    (
+        $(#[doc $($doc:tt)*])*
+        #[project = $proj_mut_ident:ident]
+        #[project_replace = $proj_replace_ident:ident]
+        $($tt:tt)*
+    ) => {
+        $crate::__pin_project_internal! {
+            [$proj_mut_ident][][$proj_replace_ident]
+            $(#[doc $($doc)*])*
+            $($tt)*
+        }
+    };
+    (
+        $(#[doc $($doc:tt)*])*
+        #[project_ref = $proj_ref_ident:ident]
+        #[project_replace = $proj_replace_ident:ident]
+        $($tt:tt)*
+    ) => {
+        $crate::__pin_project_internal! {
+            [][$proj_ref_ident][$proj_replace_ident]
             $(#[doc $($doc)*])*
             $($tt)*
         }
@@ -313,7 +349,7 @@ macro_rules! pin_project {
         $($tt:tt)*
     ) => {
         $crate::__pin_project_internal! {
-            [$proj_mut_ident][]
+            [$proj_mut_ident][][]
             $(#[doc $($doc)*])*
             $($tt)*
         }
@@ -324,7 +360,18 @@ macro_rules! pin_project {
         $($tt:tt)*
     ) => {
         $crate::__pin_project_internal! {
-            [][$proj_ref_ident]
+            [][$proj_ref_ident][]
+            $(#[doc $($doc)*])*
+            $($tt)*
+        }
+    };
+    (
+        $(#[doc $($doc:tt)*])*
+        #[project_replace = $proj_replace_ident:ident]
+        $($tt:tt)*
+    ) => {
+        $crate::__pin_project_internal! {
+            [][][$project_replace_ident]
             $(#[doc $($doc)*])*
             $($tt)*
         }
@@ -333,7 +380,7 @@ macro_rules! pin_project {
         $($tt:tt)*
     ) => {
         $crate::__pin_project_internal! {
-            [][]
+            [][][]
             $($tt)*
         }
     };
@@ -357,6 +404,7 @@ macro_rules! __pin_project_internal {
     (@struct=>internal;
         [$($proj_mut_ident:ident)?]
         [$($proj_ref_ident:ident)?]
+        [$($proj_replace_ident:ident)?]
         [$proj_vis:vis]
         [$(#[$attrs:meta])* $vis:vis struct $ident:ident]
         [$($def_generics:tt)*]
@@ -404,6 +452,19 @@ macro_rules! __pin_project_internal {
                 ),+
             }
         }
+        $crate::__pin_project_internal! { @struct=>make_proj_replace_ty=>named;
+            [$proj_vis]
+            [$($proj_replace_ident)?]
+            [make_proj_field_replace]
+            [$ident]
+            [$($impl_generics)*] [$($ty_generics)*] [$(where $($where_clause)*)?]
+            {
+                $(
+                    $(#[$pin])?
+                    $field_vis $field: $field_ty
+                ),+
+            }
+        }
 
         #[allow(explicit_outlives_requirements)]
         #[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
@@ -428,8 +489,21 @@ macro_rules! __pin_project_internal {
             }
             $crate::__pin_project_internal! { @struct=>make_proj_ty=>unnamed;
                 [$proj_vis]
-                [$($proj_ref_ident)?][ProjectionRef]
+                [$($proj_replace_ident)?][ProjectionRef]
                 [make_proj_field_ref]
+                [$ident]
+                [$($impl_generics)*] [$($ty_generics)*] [$(where $($where_clause)*)?]
+                {
+                    $(
+                        $(#[$pin])?
+                        $field_vis $field: $field_ty
+                    ),+
+                }
+            }
+            $crate::__pin_project_internal! { @struct=>make_proj_replace_ty=>unnamed;
+                [$proj_vis]
+                [$($proj_replace_ident)?][ProjectionReplace]
+                [make_proj_field_replace]
                 [$ident]
                 [$($impl_generics)*] [$($ty_generics)*] [$(where $($where_clause)*)?]
                 {
@@ -460,6 +534,18 @@ macro_rules! __pin_project_internal {
                     [$proj_vis]
                     [$($proj_ref_ident)?][ProjectionRef]
                     [project_ref get_ref]
+                    [$($ty_generics)*]
+                    {
+                        $(
+                            $(#[$pin])?
+                            $field_vis $field
+                        ),+
+                    }
+                }
+                $crate::__pin_project_internal! { @struct=>make_proj_replace_method;
+                    [$proj_vis]
+                    [$($proj_replace_ident)?][ProjectionReplace]
+                    [project_replace get_unchecked_mut mut]
                     [$($ty_generics)*]
                     {
                         $(
@@ -514,6 +600,7 @@ macro_rules! __pin_project_internal {
     (@enum=>internal;
         [$($proj_mut_ident:ident)?]
         [$($proj_ref_ident:ident)?]
+        [$($proj_replace_ident:ident)?]
         [$proj_vis:vis]
         [$(#[$attrs:meta])* $vis:vis enum $ident:ident]
         [$($def_generics:tt)*]
@@ -579,6 +666,23 @@ macro_rules! __pin_project_internal {
                 ),+
             }
         }
+        $crate::__pin_project_internal! { @enum=>make_proj_replace_ty;
+            [$proj_vis]
+            [$($proj_replace_ident)?]
+            [make_proj_field_replace]
+            [$ident]
+            [$($impl_generics)*] [$($ty_generics)*] [$(where $($where_clause)*)?]
+            {
+                $(
+                    $variant $({
+                        $(
+                            $(#[$pin])?
+                            $field: $field_ty
+                        ),+
+                    })?
+                ),+
+            }
+        }
 
         #[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
         // This lint warns of `clippy::*` generated by external macros.
@@ -610,6 +714,22 @@ macro_rules! __pin_project_internal {
                     [$proj_vis]
                     [$($proj_ref_ident)?]
                     [project_ref get_ref]
+                    [$($ty_generics)*]
+                    {
+                        $(
+                            $variant $({
+                                $(
+                                    $(#[$pin])?
+                                    $field
+                                ),+
+                            })?
+                        ),+
+                    }
+                }
+                $crate::__pin_project_internal! { @enum=>make_proj_replace_method;
+                    [$proj_vis]
+                    [$($proj_replace_ident)?]
+                    [project_replace get_unchecked_mut mut]
                     [$($ty_generics)*]
                     {
                         $(
@@ -717,6 +837,61 @@ macro_rules! __pin_project_internal {
         [$($impl_generics:tt)*] [$($ty_generics:tt)*] [$(where $($where_clause:tt)* )?]
         $($field:tt)*
     ) => {};
+
+    (@struct=>make_proj_replace_ty=>unnamed;
+        [$proj_vis:vis]
+        [$_proj_ty_ident:ident][$proj_ty_ident:ident]
+        [$make_proj_field:ident]
+        [$ident:ident]
+        [$($impl_generics:tt)*] [$($ty_generics:tt)*] [$(where $($where_clause:tt)* )?]
+        $($field:tt)*
+    ) => {};
+    (@struct=>make_proj_replace_ty=>unnamed;
+        [$proj_vis:vis]
+        [][$proj_ty_ident:ident]
+        [$make_proj_field:ident]
+        [$ident:ident]
+        [$($impl_generics:tt)*] [$($ty_generics:tt)*] [$(where $($where_clause:tt)* )?]
+        $($field:tt)*
+    ) => {
+    };
+    (@struct=>make_proj_replace_ty=>named;
+        [$proj_vis:vis]
+        [$proj_ty_ident:ident]
+        [$make_proj_field:ident]
+        [$ident:ident]
+        [$($impl_generics:tt)*] [$($ty_generics:tt)*] [$(where $($where_clause:tt)* )?]
+        {
+            $(
+                $(#[$pin:ident])?
+                $field_vis:vis $field:ident: $field_ty:ty
+            ),+
+        }
+    ) => {
+        #[allow(dead_code)] // This lint warns unused fields/variants.
+        #[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
+        #[allow(clippy::mut_mut)] // This lint warns `&mut &mut <ty>`. (only needed for project)
+        #[allow(clippy::redundant_pub_crate)]
+        #[allow(clippy::type_repetition_in_bounds)] // https://github.com/rust-lang/rust-clippy/issues/4326
+        $proj_vis struct $proj_ty_ident <$($impl_generics)*>
+        where
+            $($($where_clause)*)?
+        {
+            $(
+                $field_vis $field: $crate::__pin_project_internal!(@$make_proj_field;
+                    $(#[$pin])? $field_ty
+                )
+            ),+
+        }
+    };
+    (@struct=>make_proj_replace_ty=>named;
+        [$proj_vis:vis]
+        []
+        [$make_proj_field:ident]
+        [$ident:ident]
+        [$($impl_generics:tt)*] [$($ty_generics:tt)*] [$(where $($where_clause:tt)* )?]
+        $($field:tt)*
+    ) => {};
     // =============================================================================================
     // enum:make_proj_ty
     (@enum=>make_proj_ty;
@@ -770,6 +945,107 @@ macro_rules! __pin_project_internal {
         $($variant:tt)*
     ) => {};
 
+    (@enum=>make_proj_replace_ty;
+        [$proj_vis:vis]
+        [$proj_ty_ident:ident]
+        [$make_proj_field:ident]
+        [$ident:ident]
+        [$($impl_generics:tt)*] [$($ty_generics:tt)*] [$(where $($where_clause:tt)* )?]
+        {
+            $(
+                $variant:ident $({
+                    $(
+                        $(#[$pin:ident])?
+                        $field:ident: $field_ty:ty
+                    ),+
+                })?
+            ),+
+        }
+    ) => {
+        #[allow(dead_code)] // This lint warns unused fields/variants.
+        #[allow(single_use_lifetimes)] // https://github.com/rust-lang/rust/issues/55058
+        #[allow(clippy::mut_mut)] // This lint warns `&mut &mut <ty>`. (only needed for project)
+        #[allow(clippy::redundant_pub_crate)]
+        #[allow(clippy::type_repetition_in_bounds)] // https://github.com/rust-lang/rust-clippy/issues/4326
+        $proj_vis enum $proj_ty_ident <$($impl_generics)*>
+        where
+            $($($where_clause)*)?
+        {
+            $(
+                $variant $({
+                    $(
+                        $field: $crate::__pin_project_internal!(@$make_proj_field;
+                            $(#[$pin])? $field_ty
+                        )
+                    ),+
+                })?
+            ),+
+        }
+    };
+    (@enum=>make_proj_replace_ty;
+        [$proj_vis:vis]
+        []
+        [$make_proj_field:ident]
+        [$ident:ident]
+        [$($impl_generics:tt)*] [$($ty_generics:tt)*] [$(where $($where_clause:tt)* )?]
+        $($variant:tt)*
+    ) => {};
+
+    // =============================================================================================
+    (@make_proj_replace_block;
+        [$self_ptr: ident]
+        [$replacement: ident]
+        [$($proj_path: tt)+]
+        {
+            $(
+                $(#[$pin:ident])?
+                $field_vis:vis $field:ident
+            ),+
+        }
+    ) => {
+        let result = $($proj_path)* {
+            $(
+                $field: $crate::__pin_project_internal!(@make_replace_field_proj;
+                    $(#[$pin])? $field
+                )
+            ),+
+        };
+
+        // Destructors will run in reverse order, so next create a guard to overwrite
+        // `self` with the replacement value without calling destructors.
+        let __guard = $crate::__private::UnsafeOverwriteGuard {
+            target: $self_ptr,
+            value: $crate::__private::ManuallyDrop::new($replacement),
+        };
+
+        {
+            $(
+                $crate::__pin_project_internal!(@make_unsafe_drop_in_place_guard;
+                    $(#[$pin])? $field
+                );
+            )*
+        }
+
+        result
+    };
+    (@make_proj_replace_block;
+        [$self_ptr: ident]
+        [$replacement: ident]
+        [$($proj_path: tt)+]
+    ) => {
+
+        let result = $($proj_path)*;
+
+        // Destructors will run in reverse order, so next create a guard to overwrite
+        // `self` with the replacement value without calling destructors.
+        let __guard = $crate::__private::UnsafeOverwriteGuard {
+            target: $self_ptr,
+            value: $crate::__private::ManuallyDrop::new($replacement),
+        };
+
+        result
+    };
+
     // =============================================================================================
     // struct:make_proj_method
     (@struct=>make_proj_method;
@@ -814,6 +1090,51 @@ macro_rules! __pin_project_internal {
             $($variant)*
         }
     };
+
+    (@struct=>make_proj_replace_method;
+        [$proj_vis:vis]
+        [$proj_ty_ident:ident][$_proj_ty_ident:ident]
+        [$method_ident:ident $get_method:ident $($mut:ident)?]
+        [$($ty_generics:tt)*]
+        {
+            $(
+                $(#[$pin:ident])?
+                $field_vis:vis $field:ident
+            ),+
+        }
+    ) => {
+        $proj_vis fn $method_ident(
+            self: $crate::__private::Pin<&$($mut)? Self>,
+            replacement: Self,
+        ) -> $proj_ty_ident <$($ty_generics)*> {
+            unsafe {
+                let __replacement = replacement;
+                let __self_ptr: *mut Self = self.$get_method();
+                let Self { $($field),* } = &mut *__self_ptr;
+
+                $crate::__pin_project_internal!{@make_proj_replace_block;
+                    [__self_ptr]
+                    [__replacement]
+                    [$proj_ty_ident]
+                    {
+                        $(
+                            $(#[$pin])?
+                            $field
+                        ),+
+                    }
+                }
+            }
+        }
+    };
+    (@struct=>make_proj_replace_method;
+        [$proj_vis:vis]
+        [][$proj_ty_ident:ident]
+        [$method_ident:ident $get_method:ident $($mut:ident)?]
+        [$($ty_generics:tt)*]
+        $($variant:tt)*
+    ) => {
+    };
+
     // =============================================================================================
     // enum:make_proj_method
     (@enum=>make_proj_method;
@@ -856,6 +1177,59 @@ macro_rules! __pin_project_internal {
         }
     };
     (@enum=>make_proj_method;
+        [$proj_vis:vis]
+        []
+        [$method_ident:ident $get_method:ident $($mut:ident)?]
+        [$($ty_generics:tt)*]
+        $($variant:tt)*
+    ) => {};
+
+    (@enum=>make_proj_replace_method;
+        [$proj_vis:vis]
+        [$proj_ty_ident:ident]
+        [$method_ident:ident $get_method:ident $($mut:ident)?]
+        [$($ty_generics:tt)*]
+        {
+            $(
+                $variant:ident $({
+                    $(
+                        $(#[$pin:ident])?
+                        $field:ident
+                    ),+
+                })?
+            ),+
+        }
+    ) => {
+        $proj_vis fn $method_ident(
+            self: $crate::__private::Pin<&$($mut)? Self>,
+            replacement: Self,
+        ) -> $proj_ty_ident <$($ty_generics)*> {
+            unsafe {
+                let __replacement = replacement;
+                let __self_ptr: *mut Self = self.$get_method();
+                match &mut *__self_ptr {
+                    $(
+                        Self::$variant $({
+                            $($field),+
+                        })? => {
+                            $crate::__pin_project_internal!{@make_proj_replace_block;
+                                [__self_ptr]
+                                [__replacement]
+                                [$proj_ty_ident :: $variant]
+                                $({
+                                    $(
+                                        $(#[$pin])?
+                                        $field
+                                    ),+
+                                })?
+                            }
+                        }
+                    ),+
+                }
+            }
+        }
+    };
+    (@enum=>make_proj_replace_method;
         [$proj_vis:vis]
         []
         [$method_ident:ident $get_method:ident $($mut:ident)?]
@@ -965,6 +1339,34 @@ macro_rules! __pin_project_internal {
     };
 
     // =============================================================================================
+    // make_replace_field_proj
+    (@make_replace_field_proj;
+        #[pin]
+        $field:ident
+    ) => {
+        $crate::__private::PhantomData
+    };
+    (@make_replace_field_proj;
+        $field:ident
+    ) => {
+        $crate::__private::ptr::read($field)
+    };
+
+
+    // =============================================================================================
+    // make_unsafe_drop_in_place_guard
+    (@make_unsafe_drop_in_place_guard;
+        #[pin]
+        $field:ident
+    ) => {
+        let __guard = $crate::__private::UnsafeDropInPlaceGuard($field);
+    };
+    (@make_unsafe_drop_in_place_guard;
+        $field:ident
+    ) => {
+    };
+
+    // =============================================================================================
     // make_proj_field
     (@make_proj_field_mut;
         #[pin]
@@ -989,12 +1391,25 @@ macro_rules! __pin_project_internal {
         &'__pin ($field_ty)
     };
 
+    (@make_proj_field_replace;
+        #[pin]
+        $field_ty:ty
+    ) => {
+        $crate::__private::PhantomData<$field_ty>
+    };
+    (@make_proj_field_replace;
+        $field_ty:ty
+    ) => {
+        $field_ty
+    };
+
     // =============================================================================================
     // Parses input and determines visibility
     // struct
     (
         [$($proj_mut_ident:ident)?]
         [$($proj_ref_ident:ident)?]
+        [$($proj_replace_ident:ident)?]
 
         $(#[$attrs:meta])*
         pub struct $ident:ident $(<
@@ -1023,6 +1438,7 @@ macro_rules! __pin_project_internal {
         $crate::__pin_project_internal! { @struct=>internal;
             [$($proj_mut_ident)?]
             [$($proj_ref_ident)?]
+            [$($proj_replace_ident)?]
             [pub(crate)]
             [$(#[$attrs])* pub struct $ident]
             [$(<
@@ -1059,6 +1475,7 @@ macro_rules! __pin_project_internal {
     (
         [$($proj_mut_ident:ident)?]
         [$($proj_ref_ident:ident)?]
+        [$($proj_replace_ident:ident)?]
 
         $(#[$attrs:meta])*
         $vis:vis struct $ident:ident $(<
@@ -1087,6 +1504,7 @@ macro_rules! __pin_project_internal {
         $crate::__pin_project_internal! { @struct=>internal;
             [$($proj_mut_ident)?]
             [$($proj_ref_ident)?]
+            [$($proj_replace_ident)?]
             [$vis]
             [$(#[$attrs])* $vis struct $ident]
             [$(<
@@ -1124,6 +1542,7 @@ macro_rules! __pin_project_internal {
     (
         [$($proj_mut_ident:ident)?]
         [$($proj_ref_ident:ident)?]
+        [$($proj_replace_ident:ident)?]
 
         $(#[$attrs:meta])*
         pub enum $ident:ident $(<
@@ -1157,6 +1576,7 @@ macro_rules! __pin_project_internal {
         $crate::__pin_project_internal! { @enum=>internal;
             [$($proj_mut_ident)?]
             [$($proj_ref_ident)?]
+            [$($proj_replace_ident)?]
             [pub(crate)]
             [$(#[$attrs])* pub enum $ident]
             [$(<
@@ -1198,6 +1618,7 @@ macro_rules! __pin_project_internal {
     (
         [$($proj_mut_ident:ident)?]
         [$($proj_ref_ident:ident)?]
+        [$($proj_replace_ident:ident)?]
 
         $(#[$attrs:meta])*
         $vis:vis enum $ident:ident $(<
@@ -1231,6 +1652,7 @@ macro_rules! __pin_project_internal {
         $crate::__pin_project_internal! { @enum=>internal;
             [$($proj_mut_ident)?]
             [$($proj_ref_ident)?]
+            [$($proj_replace_ident)?]
             [$vis]
             [$(#[$attrs])* $vis enum $ident]
             [$(<
@@ -1277,8 +1699,10 @@ pub mod __private {
     #[doc(hidden)]
     pub use core::{
         marker::{PhantomData, Unpin},
+        mem::ManuallyDrop,
         ops::Drop,
         pin::Pin,
+        ptr,
     };
 
     // This is an internal helper struct used by `pin_project!`.
@@ -1286,4 +1710,32 @@ pub mod __private {
     pub struct AlwaysUnpin<T: ?Sized>(PhantomData<T>);
 
     impl<T: ?Sized> Unpin for AlwaysUnpin<T> {}
+
+    // This is an internal helper used to ensure a value is dropped.
+    #[doc(hidden)]
+    pub struct UnsafeDropInPlaceGuard<T: ?Sized>(pub *mut T);
+
+    impl<T: ?Sized> Drop for UnsafeDropInPlaceGuard<T> {
+        fn drop(&mut self) {
+            unsafe {
+                ptr::drop_in_place(self.0);
+            }
+        }
+    }
+
+    // This is an internal helper used to ensure a value is overwritten without
+    // its destructor being called.
+    #[doc(hidden)]
+    pub struct UnsafeOverwriteGuard<T> {
+        pub value: ManuallyDrop<T>,
+        pub target: *mut T,
+    }
+
+    impl<T> Drop for UnsafeOverwriteGuard<T> {
+        fn drop(&mut self) {
+            unsafe {
+                ptr::write(self.target, ptr::read(&*self.value));
+            }
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,7 +371,7 @@ macro_rules! pin_project {
         $($tt:tt)*
     ) => {
         $crate::__pin_project_internal! {
-            [][][$project_replace_ident]
+            [][][$proj_replace_ident]
             $(#[doc $($doc)*])*
             $($tt)*
         }
@@ -489,7 +489,7 @@ macro_rules! __pin_project_internal {
             }
             $crate::__pin_project_internal! { @struct=>make_proj_ty=>unnamed;
                 [$proj_vis]
-                [$($proj_replace_ident)?][ProjectionRef]
+                [$($proj_ref_ident)?][ProjectionRef]
                 [make_proj_field_ref]
                 [$ident]
                 [$($impl_generics)*] [$($ty_generics)*] [$(where $($where_clause)*)?]
@@ -1019,11 +1019,11 @@ macro_rules! __pin_project_internal {
         };
 
         {
-            $(
+            ( $(
                 $crate::__pin_project_internal!(@make_unsafe_drop_in_place_guard;
                     $(#[$pin])? $field
-                );
-            )*
+                ),
+            )* );
         }
 
         result
@@ -1359,11 +1359,12 @@ macro_rules! __pin_project_internal {
         #[pin]
         $field:ident
     ) => {
-        let __guard = $crate::__private::UnsafeDropInPlaceGuard($field);
+        $crate::__private::UnsafeDropInPlaceGuard($field)
     };
     (@make_unsafe_drop_in_place_guard;
         $field:ident
     ) => {
+        ()
     };
 
     // =============================================================================================

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,7 +557,6 @@ macro_rules! __pin_project_internal {
                 $crate::__pin_project_internal! { @struct=>make_proj_replace_method;
                     [$proj_vis]
                     [$($proj_replace_ident)?][ProjectionReplace]
-                    [project_replace get_unchecked_mut mut]
                     [$($ty_generics)*]
                     {
                         $(
@@ -741,7 +740,6 @@ macro_rules! __pin_project_internal {
                 $crate::__pin_project_internal! { @enum=>make_proj_replace_method;
                     [$proj_vis]
                     [$($proj_replace_ident)?]
-                    [project_replace get_unchecked_mut mut]
                     [$($ty_generics)*]
                     {
                         $(
@@ -1085,7 +1083,6 @@ macro_rules! __pin_project_internal {
     (@struct=>make_proj_replace_method;
         [$proj_vis:vis]
         [$proj_ty_ident:ident][$_proj_ty_ident:ident]
-        [$method_ident:ident $get_method:ident $($mut:ident)?]
         [$($ty_generics:tt)*]
         {
             $(
@@ -1094,12 +1091,12 @@ macro_rules! __pin_project_internal {
             ),+
         }
     ) => {
-        $proj_vis fn $method_ident(
-            self: $crate::__private::Pin<&$($mut)? Self>,
+        $proj_vis fn project_replace(
+            self: $crate::__private::Pin<&mut Self>,
             replacement: Self,
         ) -> $proj_ty_ident <$($ty_generics)*> {
             unsafe {
-                let __self_ptr: *mut Self = self.$get_method();
+                let __self_ptr: *mut Self = self.get_unchecked_mut();
 
                 // Destructors will run in reverse order, so next create a guard to overwrite
                 // `self` with the replacement value without calling destructors.
@@ -1125,7 +1122,6 @@ macro_rules! __pin_project_internal {
     (@struct=>make_proj_replace_method;
         [$proj_vis:vis]
         [][$proj_ty_ident:ident]
-        [$method_ident:ident $get_method:ident $($mut:ident)?]
         [$($ty_generics:tt)*]
         $($variant:tt)*
     ) => {
@@ -1183,7 +1179,6 @@ macro_rules! __pin_project_internal {
     (@enum=>make_proj_replace_method;
         [$proj_vis:vis]
         [$proj_ty_ident:ident]
-        [$method_ident:ident $get_method:ident $($mut:ident)?]
         [$($ty_generics:tt)*]
         {
             $(
@@ -1196,12 +1191,12 @@ macro_rules! __pin_project_internal {
             ),+
         }
     ) => {
-        $proj_vis fn $method_ident(
-            self: $crate::__private::Pin<&$($mut)? Self>,
+        $proj_vis fn project_replace(
+            self: $crate::__private::Pin<&mut Self>,
             replacement: Self,
         ) -> $proj_ty_ident <$($ty_generics)*> {
             unsafe {
-                let __self_ptr: *mut Self = self.$get_method();
+                let __self_ptr: *mut Self = self.get_unchecked_mut();
 
                 // Destructors will run in reverse order, so next create a guard to overwrite
                 // `self` with the replacement value without calling destructors.
@@ -1233,7 +1228,6 @@ macro_rules! __pin_project_internal {
     (@enum=>make_proj_replace_method;
         [$proj_vis:vis]
         []
-        [$method_ident:ident $get_method:ident $($mut:ident)?]
         [$($ty_generics:tt)*]
         $($variant:tt)*
     ) => {};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,18 @@
 /// }
 /// ```
 ///
+/// By passing the `#[project_replace = MyProjReplace]` attribute you may create an additional
+/// method which allows the contents of `Pin<&mut Self>` to be replaced while simultaneously moving
+/// out all unpinned fields in `Self`.
+///
+/// ```rust
+/// # use std::pin::Pin;
+/// # type MyProjReplace = ();
+/// # trait Dox {
+/// fn project_replace(self: Pin<&mut Self>, replacement: Self) -> MyProjReplace;
+/// # }
+/// ```
+///
 /// The `#[project]` (and `#[project_ref]`) attribute must precede the other
 /// attributes except for `#[doc]`. For example, the following code will not be compiled:
 ///

--- a/tests/drop_order.rs
+++ b/tests/drop_order.rs
@@ -1,0 +1,168 @@
+#![warn(rust_2018_idioms, single_use_lifetimes)]
+
+// Refs: https://doc.rust-lang.org/reference/destructors.html
+
+use pin_project_lite::pin_project;
+use std::{cell::Cell, panic, pin::Pin, thread};
+
+struct D<'a>(&'a Cell<usize>, usize);
+
+impl Drop for D<'_> {
+    fn drop(&mut self) {
+        if !thread::panicking() {
+            let old = self.0.replace(self.1);
+            assert_eq!(old, self.1 - 1);
+        }
+    }
+}
+
+pin_project! {
+#[project = StructPinnedProj]
+#[project_ref = StructPinnedProjRef]
+#[project_replace = StructPinnedProjReplace]
+struct StructPinned<'a> {
+    #[pin]
+    f1: D<'a>,
+    #[pin]
+    f2: D<'a>,
+}
+}
+
+pin_project! {
+#[project = StructUnpinnedProj]
+#[project_ref = StructUnpinnedProjRef]
+#[project_replace = StructUnpinnedProjReplace]
+struct StructUnpinned<'a> {
+    f1: D<'a>,
+    f2: D<'a>,
+}
+}
+
+pin_project! {
+#[project_replace = EnumProjReplace]
+enum Enum<'a> {
+    #[allow(dead_code)] // false positive that fixed in Rust 1.38
+    StructPinned {
+        #[pin]
+        f1: D<'a>,
+        #[pin]
+        f2: D<'a>,
+    },
+    #[allow(dead_code)] // false positive that fixed in Rust 1.38
+    StructUnpinned {
+        f1: D<'a>,
+        f2: D<'a>,
+    },
+}
+}
+
+#[test]
+fn struct_pinned() {
+    {
+        let c = Cell::new(0);
+        let _x = StructPinned { f1: D(&c, 1), f2: D(&c, 2) };
+    }
+    {
+        let c = Cell::new(0);
+        let mut x = StructPinned { f1: D(&c, 1), f2: D(&c, 2) };
+        let y = Pin::new(&mut x);
+        let _z = y.project_replace(StructPinned { f1: D(&c, 3), f2: D(&c, 4) });
+    }
+}
+
+#[test]
+fn struct_unpinned() {
+    {
+        let c = Cell::new(0);
+        let _x = StructUnpinned { f1: D(&c, 1), f2: D(&c, 2) };
+    }
+    {
+        let c = Cell::new(0);
+        let mut x = StructUnpinned { f1: D(&c, 1), f2: D(&c, 2) };
+        let y = Pin::new(&mut x);
+        let _z = y.project_replace(StructUnpinned { f1: D(&c, 3), f2: D(&c, 4) });
+    }
+}
+
+#[test]
+fn enum_struct() {
+    {
+        let c = Cell::new(0);
+        let _x = Enum::StructPinned { f1: D(&c, 1), f2: D(&c, 2) };
+    }
+    {
+        let c = Cell::new(0);
+        let mut x = Enum::StructPinned { f1: D(&c, 1), f2: D(&c, 2) };
+        let y = Pin::new(&mut x);
+        let _z = y.project_replace(Enum::StructPinned { f1: D(&c, 3), f2: D(&c, 4) });
+    }
+
+    {
+        let c = Cell::new(0);
+        let _x = Enum::StructUnpinned { f1: D(&c, 1), f2: D(&c, 2) };
+    }
+    {
+        let c = Cell::new(0);
+        let mut x = Enum::StructUnpinned { f1: D(&c, 1), f2: D(&c, 2) };
+        let y = Pin::new(&mut x);
+        let _z = y.project_replace(Enum::StructUnpinned { f1: D(&c, 3), f2: D(&c, 4) });
+    }
+}
+
+// https://github.com/rust-lang/rust/issues/47949
+// https://github.com/taiki-e/pin-project/pull/194#discussion_r419098111
+#[allow(clippy::many_single_char_names)]
+#[test]
+fn project_replace_panic() {
+    pin_project! {
+    #[project_replace = SProjReplace]
+    struct S<T, U> {
+        #[pin]
+        pinned: T,
+        unpinned: U,
+    }
+    }
+
+    struct D<'a>(&'a mut bool, bool);
+    impl Drop for D<'_> {
+        fn drop(&mut self) {
+            *self.0 = true;
+            if self.1 {
+                panic!()
+            }
+        }
+    }
+
+    let (mut a, mut b, mut c, mut d) = (false, false, false, false);
+    let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        let mut x = S { pinned: D(&mut a, true), unpinned: D(&mut b, false) };
+        let _y = Pin::new(&mut x)
+            .project_replace(S { pinned: D(&mut c, false), unpinned: D(&mut d, false) });
+        // Previous `x.pinned` was dropped and panicked when `project_replace` is
+        // called, so this is unreachable.
+        unreachable!();
+    }));
+    assert!(res.is_err());
+    assert!(a);
+    assert!(b);
+    assert!(c);
+    assert!(d);
+
+    let (mut a, mut b, mut c, mut d) = (false, false, false, false);
+    let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        let mut x = S { pinned: D(&mut a, false), unpinned: D(&mut b, true) };
+        {
+            let _y = Pin::new(&mut x)
+                .project_replace(S { pinned: D(&mut c, false), unpinned: D(&mut d, false) });
+            // `_y` (previous `x.unpinned`) live to the end of this scope, so
+            // this is not unreachable.
+            // unreachable!();
+        }
+        unreachable!();
+    }));
+    assert!(res.is_err());
+    assert!(a);
+    assert!(b);
+    assert!(c);
+    assert!(d);
+}

--- a/tests/expand/tests/expand/default-enum.expanded.rs
+++ b/tests/expand/tests/expand/default-enum.expanded.rs
@@ -98,8 +98,10 @@ const _: () = {
                             value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
                         };
                         {
-                            let __guard =
-                                ::pin_project_lite::__private::UnsafeDropInPlaceGuard(pinned);
+                            (
+                                ::pin_project_lite::__private::UnsafeDropInPlaceGuard(pinned),
+                                (),
+                            );
                         }
                         result
                     }

--- a/tests/expand/tests/expand/default-enum.expanded.rs
+++ b/tests/expand/tests/expand/default-enum.expanded.rs
@@ -85,17 +85,16 @@ const _: () = {
             replacement: Self,
         ) -> EnumProjReplace<T, U> {
             unsafe {
-                let __replacement = replacement;
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
+                let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
+                    target: __self_ptr,
+                    value: ::pin_project_lite::__private::ManuallyDrop::new(replacement),
+                };
                 match &mut *__self_ptr {
                     Self::Struct { pinned, unpinned } => {
                         let result = EnumProjReplace::Struct {
                             pinned: ::pin_project_lite::__private::PhantomData,
                             unpinned: ::pin_project_lite::__private::ptr::read(unpinned),
-                        };
-                        let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
-                            target: __self_ptr,
-                            value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
                         };
                         {
                             (
@@ -105,14 +104,7 @@ const _: () = {
                         }
                         result
                     }
-                    Self::Unit => {
-                        let result = EnumProjReplace::Unit;
-                        let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
-                            target: __self_ptr,
-                            value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
-                        };
-                        result
-                    }
+                    Self::Unit => EnumProjReplace::Unit,
                 }
             }
         }

--- a/tests/expand/tests/expand/default-enum.expanded.rs
+++ b/tests/expand/tests/expand/default-enum.expanded.rs
@@ -37,6 +37,18 @@ where
     },
     Unit,
 }
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
+enum EnumProjReplace<T, U> {
+    Struct {
+        pinned: ::pin_project_lite::__private::PhantomData<T>,
+        unpinned: U,
+    },
+    Unit,
+}
 #[allow(single_use_lifetimes)]
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::used_underscore_binding)]
@@ -65,6 +77,40 @@ const _: () = {
                         unpinned: unpinned,
                     },
                     Self::Unit => EnumProjRef::Unit,
+                }
+            }
+        }
+        fn project_replace(
+            self: ::pin_project_lite::__private::Pin<&mut Self>,
+            replacement: Self,
+        ) -> EnumProjReplace<T, U> {
+            unsafe {
+                let __replacement = replacement;
+                let __self_ptr: *mut Self = self.get_unchecked_mut();
+                match &mut *__self_ptr {
+                    Self::Struct { pinned, unpinned } => {
+                        let result = EnumProjReplace::Struct {
+                            pinned: ::pin_project_lite::__private::PhantomData,
+                            unpinned: ::pin_project_lite::__private::ptr::read(unpinned),
+                        };
+                        let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
+                            target: __self_ptr,
+                            value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
+                        };
+                        {
+                            let __guard =
+                                ::pin_project_lite::__private::UnsafeDropInPlaceGuard(pinned);
+                        }
+                        result
+                    }
+                    Self::Unit => {
+                        let result = EnumProjReplace::Unit;
+                        let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
+                            target: __self_ptr,
+                            value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
+                        };
+                        result
+                    }
                 }
             }
         }

--- a/tests/expand/tests/expand/default-enum.rs
+++ b/tests/expand/tests/expand/default-enum.rs
@@ -3,6 +3,7 @@ use pin_project_lite::pin_project;
 pin_project! {
     #[project = EnumProj]
     #[project_ref = EnumProjRef]
+    #[project_replace = EnumProjReplace]
     enum Enum<T, U> {
         Struct {
             #[pin]

--- a/tests/expand/tests/expand/multifields-enum.expanded.rs
+++ b/tests/expand/tests/expand/multifields-enum.expanded.rs
@@ -23,6 +23,7 @@ enum EnumProjReplace<T, U> {
     Unit,
 }
 #[allow(single_use_lifetimes)]
+#[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {

--- a/tests/expand/tests/expand/multifields-enum.expanded.rs
+++ b/tests/expand/tests/expand/multifields-enum.expanded.rs
@@ -31,8 +31,11 @@ const _: () = {
             replacement: Self,
         ) -> EnumProjReplace<T, U> {
             unsafe {
-                let __replacement = replacement;
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
+                let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
+                    target: __self_ptr,
+                    value: ::pin_project_lite::__private::ManuallyDrop::new(replacement),
+                };
                 match &mut *__self_ptr {
                     Self::Struct {
                         pinned1,
@@ -46,10 +49,6 @@ const _: () = {
                             unpinned1: ::pin_project_lite::__private::ptr::read(unpinned1),
                             unpinned2: ::pin_project_lite::__private::ptr::read(unpinned2),
                         };
-                        let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
-                            target: __self_ptr,
-                            value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
-                        };
                         {
                             (
                                 ::pin_project_lite::__private::UnsafeDropInPlaceGuard(pinned1),
@@ -60,14 +59,7 @@ const _: () = {
                         }
                         result
                     }
-                    Self::Unit => {
-                        let result = EnumProjReplace::Unit;
-                        let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
-                            target: __self_ptr,
-                            value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
-                        };
-                        result
-                    }
+                    Self::Unit => EnumProjReplace::Unit,
                 }
             }
         }

--- a/tests/expand/tests/expand/multifields-enum.expanded.rs
+++ b/tests/expand/tests/expand/multifields-enum.expanded.rs
@@ -1,0 +1,95 @@
+use pin_project_lite::pin_project;
+enum Enum<T, U> {
+    Struct {
+        pinned1: T,
+        pinned2: T,
+        unpinned1: U,
+        unpinned2: U,
+    },
+    Unit,
+}
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
+enum EnumProjReplace<T, U> {
+    Struct {
+        pinned1: ::pin_project_lite::__private::PhantomData<T>,
+        pinned2: ::pin_project_lite::__private::PhantomData<T>,
+        unpinned1: U,
+        unpinned2: U,
+    },
+    Unit,
+}
+#[allow(single_use_lifetimes)]
+#[allow(clippy::used_underscore_binding)]
+const _: () = {
+    impl<T, U> Enum<T, U> {
+        fn project_replace(
+            self: ::pin_project_lite::__private::Pin<&mut Self>,
+            replacement: Self,
+        ) -> EnumProjReplace<T, U> {
+            unsafe {
+                let __replacement = replacement;
+                let __self_ptr: *mut Self = self.get_unchecked_mut();
+                match &mut *__self_ptr {
+                    Self::Struct {
+                        pinned1,
+                        pinned2,
+                        unpinned1,
+                        unpinned2,
+                    } => {
+                        let result = EnumProjReplace::Struct {
+                            pinned1: ::pin_project_lite::__private::PhantomData,
+                            pinned2: ::pin_project_lite::__private::PhantomData,
+                            unpinned1: ::pin_project_lite::__private::ptr::read(unpinned1),
+                            unpinned2: ::pin_project_lite::__private::ptr::read(unpinned2),
+                        };
+                        let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
+                            target: __self_ptr,
+                            value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
+                        };
+                        {
+                            (
+                                ::pin_project_lite::__private::UnsafeDropInPlaceGuard(pinned1),
+                                ::pin_project_lite::__private::UnsafeDropInPlaceGuard(pinned2),
+                                (),
+                                (),
+                            );
+                        }
+                        result
+                    }
+                    Self::Unit => {
+                        let result = EnumProjReplace::Unit;
+                        let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
+                            target: __self_ptr,
+                            value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
+                        };
+                        result
+                    }
+                }
+            }
+        }
+    }
+    #[allow(non_snake_case)]
+    struct __Origin<'__pin, T, U> {
+        __dummy_lifetime: ::pin_project_lite::__private::PhantomData<&'__pin ()>,
+        Struct: (
+            T,
+            T,
+            ::pin_project_lite::__private::AlwaysUnpin<U>,
+            ::pin_project_lite::__private::AlwaysUnpin<U>,
+        ),
+        Unit: (),
+    }
+    impl<'__pin, T, U> ::pin_project_lite::__private::Unpin for Enum<T, U> where
+        __Origin<'__pin, T, U>: ::pin_project_lite::__private::Unpin
+    {
+    }
+    trait MustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::pin_project_lite::__private::Drop> MustNotImplDrop for T {}
+    impl<T, U> MustNotImplDrop for Enum<T, U> {}
+};
+fn main() {}

--- a/tests/expand/tests/expand/multifields-enum.rs
+++ b/tests/expand/tests/expand/multifields-enum.rs
@@ -1,0 +1,18 @@
+use pin_project_lite::pin_project;
+
+pin_project! {
+#[project_replace = EnumProjReplace]
+enum Enum<T, U> {
+    Struct {
+        #[pin]
+        pinned1: T,
+        #[pin]
+        pinned2: T,
+        unpinned1: U,
+        unpinned2: U,
+    },
+    Unit,
+}
+}
+
+fn main() {}

--- a/tests/expand/tests/expand/multifields-struct.expanded.rs
+++ b/tests/expand/tests/expand/multifields-struct.expanded.rs
@@ -91,8 +91,11 @@ const _: () = {
             replacement: Self,
         ) -> StructProjRef<T, U> {
             unsafe {
-                let __replacement = replacement;
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
+                let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
+                    target: __self_ptr,
+                    value: ::pin_project_lite::__private::ManuallyDrop::new(replacement),
+                };
                 let Self {
                     pinned1,
                     pinned2,
@@ -104,10 +107,6 @@ const _: () = {
                     pinned2: ::pin_project_lite::__private::PhantomData,
                     unpinned1: ::pin_project_lite::__private::ptr::read(unpinned1),
                     unpinned2: ::pin_project_lite::__private::ptr::read(unpinned2),
-                };
-                let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
-                    target: __self_ptr,
-                    value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
                 };
                 {
                     (

--- a/tests/expand/tests/expand/multifields-struct.expanded.rs
+++ b/tests/expand/tests/expand/multifields-struct.expanded.rs
@@ -1,0 +1,148 @@
+use pin_project_lite::pin_project;
+struct Struct<T, U> {
+    pinned1: T,
+    pinned2: T,
+    unpinned1: U,
+    unpinned2: U,
+}
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
+struct StructProjRef<T, U> {
+    pinned1: ::pin_project_lite::__private::PhantomData<T>,
+    pinned2: ::pin_project_lite::__private::PhantomData<T>,
+    unpinned1: U,
+    unpinned2: U,
+}
+#[allow(explicit_outlives_requirements)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::used_underscore_binding)]
+const _: () = {
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::redundant_pub_crate)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct Projection<'__pin, T, U>
+    where
+        Struct<T, U>: '__pin,
+    {
+        pinned1: ::pin_project_lite::__private::Pin<&'__pin mut (T)>,
+        pinned2: ::pin_project_lite::__private::Pin<&'__pin mut (T)>,
+        unpinned1: &'__pin mut (U),
+        unpinned2: &'__pin mut (U),
+    }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::redundant_pub_crate)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct ProjectionRef<'__pin, T, U>
+    where
+        Struct<T, U>: '__pin,
+    {
+        pinned1: ::pin_project_lite::__private::Pin<&'__pin (T)>,
+        pinned2: ::pin_project_lite::__private::Pin<&'__pin (T)>,
+        unpinned1: &'__pin (U),
+        unpinned2: &'__pin (U),
+    }
+    impl<T, U> Struct<T, U> {
+        fn project<'__pin>(
+            self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,
+        ) -> Projection<'__pin, T, U> {
+            unsafe {
+                let Self {
+                    pinned1,
+                    pinned2,
+                    unpinned1,
+                    unpinned2,
+                } = self.get_unchecked_mut();
+                Projection {
+                    pinned1: ::pin_project_lite::__private::Pin::new_unchecked(pinned1),
+                    pinned2: ::pin_project_lite::__private::Pin::new_unchecked(pinned2),
+                    unpinned1: unpinned1,
+                    unpinned2: unpinned2,
+                }
+            }
+        }
+        fn project_ref<'__pin>(
+            self: ::pin_project_lite::__private::Pin<&'__pin Self>,
+        ) -> ProjectionRef<'__pin, T, U> {
+            unsafe {
+                let Self {
+                    pinned1,
+                    pinned2,
+                    unpinned1,
+                    unpinned2,
+                } = self.get_ref();
+                ProjectionRef {
+                    pinned1: ::pin_project_lite::__private::Pin::new_unchecked(pinned1),
+                    pinned2: ::pin_project_lite::__private::Pin::new_unchecked(pinned2),
+                    unpinned1: unpinned1,
+                    unpinned2: unpinned2,
+                }
+            }
+        }
+        fn project_replace(
+            self: ::pin_project_lite::__private::Pin<&mut Self>,
+            replacement: Self,
+        ) -> StructProjRef<T, U> {
+            unsafe {
+                let __replacement = replacement;
+                let __self_ptr: *mut Self = self.get_unchecked_mut();
+                let Self {
+                    pinned1,
+                    pinned2,
+                    unpinned1,
+                    unpinned2,
+                } = &mut *__self_ptr;
+                let result = StructProjRef {
+                    pinned1: ::pin_project_lite::__private::PhantomData,
+                    pinned2: ::pin_project_lite::__private::PhantomData,
+                    unpinned1: ::pin_project_lite::__private::ptr::read(unpinned1),
+                    unpinned2: ::pin_project_lite::__private::ptr::read(unpinned2),
+                };
+                let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
+                    target: __self_ptr,
+                    value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
+                };
+                {
+                    (
+                        ::pin_project_lite::__private::UnsafeDropInPlaceGuard(pinned1),
+                        ::pin_project_lite::__private::UnsafeDropInPlaceGuard(pinned2),
+                        (),
+                        (),
+                    );
+                }
+                result
+            }
+        }
+    }
+    #[allow(non_snake_case)]
+    struct __Origin<'__pin, T, U> {
+        __dummy_lifetime: ::pin_project_lite::__private::PhantomData<&'__pin ()>,
+        pinned1: T,
+        pinned2: T,
+        unpinned1: ::pin_project_lite::__private::AlwaysUnpin<U>,
+        unpinned2: ::pin_project_lite::__private::AlwaysUnpin<U>,
+    }
+    impl<'__pin, T, U> ::pin_project_lite::__private::Unpin for Struct<T, U> where
+        __Origin<'__pin, T, U>: ::pin_project_lite::__private::Unpin
+    {
+    }
+    trait MustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::pin_project_lite::__private::Drop> MustNotImplDrop for T {}
+    impl<T, U> MustNotImplDrop for Struct<T, U> {}
+    #[forbid(safe_packed_borrows)]
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned1;
+        let _ = &this.pinned2;
+        let _ = &this.unpinned1;
+        let _ = &this.unpinned2;
+    }
+};
+fn main() {}

--- a/tests/expand/tests/expand/multifields-struct.expanded.rs
+++ b/tests/expand/tests/expand/multifields-struct.expanded.rs
@@ -10,7 +10,7 @@ struct Struct<T, U> {
 #[allow(clippy::mut_mut)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::type_repetition_in_bounds)]
-struct StructProjRef<T, U> {
+struct StructProjReplace<T, U> {
     pinned1: ::pin_project_lite::__private::PhantomData<T>,
     pinned2: ::pin_project_lite::__private::PhantomData<T>,
     unpinned1: U,
@@ -18,13 +18,16 @@ struct StructProjRef<T, U> {
 }
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
+#[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::redundant_pub_crate)]
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     #[allow(dead_code)]
     #[allow(single_use_lifetimes)]
+    #[allow(clippy::unknown_clippy_lints)]
     #[allow(clippy::mut_mut)]
     #[allow(clippy::redundant_pub_crate)]
+    #[allow(clippy::ref_option_ref)]
     #[allow(clippy::type_repetition_in_bounds)]
     struct Projection<'__pin, T, U>
     where
@@ -37,8 +40,10 @@ const _: () = {
     }
     #[allow(dead_code)]
     #[allow(single_use_lifetimes)]
+    #[allow(clippy::unknown_clippy_lints)]
     #[allow(clippy::mut_mut)]
     #[allow(clippy::redundant_pub_crate)]
+    #[allow(clippy::ref_option_ref)]
     #[allow(clippy::type_repetition_in_bounds)]
     struct ProjectionRef<'__pin, T, U>
     where
@@ -89,7 +94,7 @@ const _: () = {
         fn project_replace(
             self: ::pin_project_lite::__private::Pin<&mut Self>,
             replacement: Self,
-        ) -> StructProjRef<T, U> {
+        ) -> StructProjReplace<T, U> {
             unsafe {
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
                 let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
@@ -102,7 +107,7 @@ const _: () = {
                     unpinned1,
                     unpinned2,
                 } = &mut *__self_ptr;
-                let result = StructProjRef {
+                let result = StructProjReplace {
                     pinned1: ::pin_project_lite::__private::PhantomData,
                     pinned2: ::pin_project_lite::__private::PhantomData,
                     unpinned1: ::pin_project_lite::__private::ptr::read(unpinned1),

--- a/tests/expand/tests/expand/multifields-struct.rs
+++ b/tests/expand/tests/expand/multifields-struct.rs
@@ -1,7 +1,7 @@
 use pin_project_lite::pin_project;
 
 pin_project! {
-#[project_replace = StructProjRef]
+#[project_replace = StructProjReplace]
 struct Struct<T, U> {
     #[pin]
     pinned1: T,

--- a/tests/expand/tests/expand/multifields-struct.rs
+++ b/tests/expand/tests/expand/multifields-struct.rs
@@ -1,0 +1,15 @@
+use pin_project_lite::pin_project;
+
+pin_project! {
+#[project_replace = StructProjRef]
+struct Struct<T, U> {
+    #[pin]
+    pinned1: T,
+    #[pin]
+    pinned2: T,
+    unpinned1: U,
+    unpinned2: U,
+}
+}
+
+fn main() {}

--- a/tests/expand/tests/expand/naming-enum-all.expanded.rs
+++ b/tests/expand/tests/expand/naming-enum-all.expanded.rs
@@ -98,8 +98,10 @@ const _: () = {
                             value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
                         };
                         {
-                            let __guard =
-                                ::pin_project_lite::__private::UnsafeDropInPlaceGuard(pinned);
+                            (
+                                ::pin_project_lite::__private::UnsafeDropInPlaceGuard(pinned),
+                                (),
+                            );
                         }
                         result
                     }

--- a/tests/expand/tests/expand/naming-enum-all.expanded.rs
+++ b/tests/expand/tests/expand/naming-enum-all.expanded.rs
@@ -85,17 +85,16 @@ const _: () = {
             replacement: Self,
         ) -> EnumProjReplace<T, U> {
             unsafe {
-                let __replacement = replacement;
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
+                let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
+                    target: __self_ptr,
+                    value: ::pin_project_lite::__private::ManuallyDrop::new(replacement),
+                };
                 match &mut *__self_ptr {
                     Self::Struct { pinned, unpinned } => {
                         let result = EnumProjReplace::Struct {
                             pinned: ::pin_project_lite::__private::PhantomData,
                             unpinned: ::pin_project_lite::__private::ptr::read(unpinned),
-                        };
-                        let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
-                            target: __self_ptr,
-                            value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
                         };
                         {
                             (
@@ -105,14 +104,7 @@ const _: () = {
                         }
                         result
                     }
-                    Self::Unit => {
-                        let result = EnumProjReplace::Unit;
-                        let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
-                            target: __self_ptr,
-                            value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
-                        };
-                        result
-                    }
+                    Self::Unit => EnumProjReplace::Unit,
                 }
             }
         }

--- a/tests/expand/tests/expand/naming-enum-all.expanded.rs
+++ b/tests/expand/tests/expand/naming-enum-all.expanded.rs
@@ -37,6 +37,18 @@ where
     },
     Unit,
 }
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
+enum EnumProjReplace<T, U> {
+    Struct {
+        pinned: ::pin_project_lite::__private::PhantomData<T>,
+        unpinned: U,
+    },
+    Unit,
+}
 #[allow(single_use_lifetimes)]
 #[allow(clippy::unknown_clippy_lints)]
 #[allow(clippy::used_underscore_binding)]
@@ -65,6 +77,40 @@ const _: () = {
                         unpinned: unpinned,
                     },
                     Self::Unit => EnumProjRef::Unit,
+                }
+            }
+        }
+        fn project_replace(
+            self: ::pin_project_lite::__private::Pin<&mut Self>,
+            replacement: Self,
+        ) -> EnumProjReplace<T, U> {
+            unsafe {
+                let __replacement = replacement;
+                let __self_ptr: *mut Self = self.get_unchecked_mut();
+                match &mut *__self_ptr {
+                    Self::Struct { pinned, unpinned } => {
+                        let result = EnumProjReplace::Struct {
+                            pinned: ::pin_project_lite::__private::PhantomData,
+                            unpinned: ::pin_project_lite::__private::ptr::read(unpinned),
+                        };
+                        let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
+                            target: __self_ptr,
+                            value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
+                        };
+                        {
+                            let __guard =
+                                ::pin_project_lite::__private::UnsafeDropInPlaceGuard(pinned);
+                        }
+                        result
+                    }
+                    Self::Unit => {
+                        let result = EnumProjReplace::Unit;
+                        let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
+                            target: __self_ptr,
+                            value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
+                        };
+                        result
+                    }
                 }
             }
         }

--- a/tests/expand/tests/expand/naming-enum-all.rs
+++ b/tests/expand/tests/expand/naming-enum-all.rs
@@ -3,6 +3,7 @@ use pin_project_lite::pin_project;
 pin_project! {
     #[project = EnumProj]
     #[project_ref = EnumProjRef]
+    #[project_replace = EnumProjReplace]
     enum Enum<T, U> {
         Struct {
             #[pin]

--- a/tests/expand/tests/expand/naming-struct-all.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct-all.expanded.rs
@@ -31,6 +31,15 @@ where
     pinned: ::pin_project_lite::__private::Pin<&'__pin (T)>,
     unpinned: &'__pin (U),
 }
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::type_repetition_in_bounds)]
+struct StructProjReplace<T, U> {
+    pinned: ::pin_project_lite::__private::PhantomData<T>,
+    unpinned: U,
+}
 #[allow(explicit_outlives_requirements)]
 #[allow(single_use_lifetimes)]
 #[allow(clippy::unknown_clippy_lints)]
@@ -58,6 +67,28 @@ const _: () = {
                     pinned: ::pin_project_lite::__private::Pin::new_unchecked(pinned),
                     unpinned: unpinned,
                 }
+            }
+        }
+        fn project_replace(
+            self: ::pin_project_lite::__private::Pin<&mut Self>,
+            replacement: Self,
+        ) -> StructProjReplace<T, U> {
+            unsafe {
+                let __replacement = replacement;
+                let __self_ptr: *mut Self = self.get_unchecked_mut();
+                let Self { pinned, unpinned } = &mut *__self_ptr;
+                let result = StructProjReplace {
+                    pinned: ::pin_project_lite::__private::PhantomData,
+                    unpinned: ::pin_project_lite::__private::ptr::read(unpinned),
+                };
+                let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
+                    target: __self_ptr,
+                    value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
+                };
+                {
+                    let __guard = ::pin_project_lite::__private::UnsafeDropInPlaceGuard(pinned);
+                }
+                result
             }
         }
     }

--- a/tests/expand/tests/expand/naming-struct-all.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct-all.expanded.rs
@@ -74,16 +74,15 @@ const _: () = {
             replacement: Self,
         ) -> StructProjReplace<T, U> {
             unsafe {
-                let __replacement = replacement;
                 let __self_ptr: *mut Self = self.get_unchecked_mut();
+                let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
+                    target: __self_ptr,
+                    value: ::pin_project_lite::__private::ManuallyDrop::new(replacement),
+                };
                 let Self { pinned, unpinned } = &mut *__self_ptr;
                 let result = StructProjReplace {
                     pinned: ::pin_project_lite::__private::PhantomData,
                     unpinned: ::pin_project_lite::__private::ptr::read(unpinned),
-                };
-                let __guard = ::pin_project_lite::__private::UnsafeOverwriteGuard {
-                    target: __self_ptr,
-                    value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
                 };
                 {
                     (

--- a/tests/expand/tests/expand/naming-struct-all.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct-all.expanded.rs
@@ -86,7 +86,10 @@ const _: () = {
                     value: ::pin_project_lite::__private::ManuallyDrop::new(__replacement),
                 };
                 {
-                    let __guard = ::pin_project_lite::__private::UnsafeDropInPlaceGuard(pinned);
+                    (
+                        ::pin_project_lite::__private::UnsafeDropInPlaceGuard(pinned),
+                        (),
+                    );
                 }
                 result
             }

--- a/tests/expand/tests/expand/naming-struct-all.rs
+++ b/tests/expand/tests/expand/naming-struct-all.rs
@@ -3,6 +3,7 @@ use pin_project_lite::pin_project;
 pin_project! {
     #[project = StructProj]
     #[project_ref = StructProjRef]
+    #[project_replace = StructProjReplace]
     struct Struct<T, U> {
         #[pin]
         pinned: T,

--- a/tests/expand/tests/expand/naming-struct-ref.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct-ref.expanded.rs
@@ -37,18 +37,6 @@ const _: () = {
         pinned: ::pin_project_lite::__private::Pin<&'__pin mut (T)>,
         unpinned: &'__pin mut (U),
     }
-    #[allow(dead_code)]
-    #[allow(single_use_lifetimes)]
-    #[allow(clippy::mut_mut)]
-    #[allow(clippy::redundant_pub_crate)]
-    #[allow(clippy::type_repetition_in_bounds)]
-    struct ProjectionRef<'__pin, T, U>
-    where
-        Struct<T, U>: '__pin,
-    {
-        pinned: ::pin_project_lite::__private::Pin<&'__pin (T)>,
-        unpinned: &'__pin (U),
-    }
     impl<T, U> Struct<T, U> {
         fn project<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,

--- a/tests/expand/tests/expand/naming-struct-ref.expanded.rs
+++ b/tests/expand/tests/expand/naming-struct-ref.expanded.rs
@@ -37,6 +37,18 @@ const _: () = {
         pinned: ::pin_project_lite::__private::Pin<&'__pin mut (T)>,
         unpinned: &'__pin mut (U),
     }
+    #[allow(dead_code)]
+    #[allow(single_use_lifetimes)]
+    #[allow(clippy::mut_mut)]
+    #[allow(clippy::redundant_pub_crate)]
+    #[allow(clippy::type_repetition_in_bounds)]
+    struct ProjectionRef<'__pin, T, U>
+    where
+        Struct<T, U>: '__pin,
+    {
+        pinned: ::pin_project_lite::__private::Pin<&'__pin (T)>,
+        unpinned: &'__pin (U),
+    }
     impl<T, U> Struct<T, U> {
         fn project<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,


### PR DESCRIPTION
To mirror the same method in [pin-project](https://docs.rs/pin-project/1.0.3/pin_project/).

Currently this has to been specified explicitly via an attribute as it
otherwise breaks on `!Sized` types.

Could use some cleanup of the generated code and some tests around drop order (if possible) but other than that this did not seems to be as hard as I thought.

Closes #42