### PR TITLE
Run Miri on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,15 @@ jobs:
         run: cargo install -f cargo-expand --root ${{ runner.tool_cache }}/cargo-expand
       - run: cargo test -p expandtest
 
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: taiki-e/github-actions/install-rust@main
+        with:
+          component: miri
+      - run: cargo miri test --all
+
   clippy:
     runs-on: ubuntu-latest
     steps:
@@ -127,6 +136,7 @@ jobs:
       - test
       - build
       - expandtest
+      - miri
       - clippy
       - rustfmt
       - rustdoc

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,3 +1,4 @@
+#![cfg(not(miri))]
 #![warn(rust_2018_idioms, single_use_lifetimes)]
 
 use std::env;

--- a/tests/expand/tests/expandtest.rs
+++ b/tests/expand/tests/expandtest.rs
@@ -1,3 +1,4 @@
+#![cfg(not(miri))]
 #![warn(rust_2018_idioms, single_use_lifetimes)]
 
 use std::{

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -40,8 +40,6 @@
 
 // Check interoperability with rustc and clippy lints.
 
-mod auxiliary;
-
 pub mod basic {
     include!("include/basic.rs");
 }
@@ -239,7 +237,7 @@ pub mod clippy_used_underscore_binding {
     }
 }
 
-mod clippy_ref_option_ref {
+pub mod clippy_ref_option_ref {
     use pin_project_lite::pin_project;
 
     pin_project! {


### PR DESCRIPTION
The pin guarantees are guarantees of a library, so Miri does not detect
violations of the pin API. However, if the generated unsafe code causes
UB, Miri may be possible to detect it.

https://github.com/taiki-e/pin-project/pull/288