### PR TITLE
Support item attributes in any order

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1323,7 +1323,10 @@ macro_rules! __pin_project_internal {
         $($tt:tt)*
     ) => {
         $crate::__pin_project_internal! {
-            [$proj_mut_ident][$($proj_ref_ident)?][$($proj_replace_ident)?][$($attrs)*]
+            [$proj_mut_ident]
+            [$($proj_ref_ident)?]
+            [$($proj_replace_ident)?]
+            [$($attrs)*]
             $($tt)*
         }
     };
@@ -1338,7 +1341,10 @@ macro_rules! __pin_project_internal {
         $($tt:tt)*
     } => {
         $crate::__pin_project_internal! {
-            [$($proj_mut_ident)?][$proj_ref_ident][$($proj_replace_ident)?][$($attrs)*]
+            [$($proj_mut_ident)?]
+            [$proj_ref_ident]
+            [$($proj_replace_ident)?]
+            [$($attrs)*]
             $($tt)*
         }
     };
@@ -1353,7 +1359,10 @@ macro_rules! __pin_project_internal {
         $($tt:tt)*
     } => {
         $crate::__pin_project_internal! {
-            [$($proj_mut_ident)?][$($proj_ref_ident)?][$proj_replace_ident][$($attrs)*]
+            [$($proj_mut_ident)?]
+            [$($proj_ref_ident)?]
+            [$proj_replace_ident]
+            [$($attrs)*]
             $($tt)*
         }
     };
@@ -1368,7 +1377,10 @@ macro_rules! __pin_project_internal {
         $($tt:tt)*
     } => {
         $crate::__pin_project_internal! {
-            [$($proj_mut_ident)?][$($proj_ref_ident)?][$($proj_replace_ident)?][$($attrs)* #[$($attr)*]]
+            [$($proj_mut_ident)?]
+            [$($proj_ref_ident)?]
+            [$($proj_replace_ident)?]
+            [$($attrs)* #[$($attr)*]]
             $($tt)*
         }
     };

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -600,6 +600,7 @@ fn attrs() {
 
     pin_project! {
         /// dox1
+        #[derive(Clone)]
         #[project = Enum2Proj]
         #[project_ref = Enum2ProjRef]
         /// dox2


### PR DESCRIPTION
Uses a tt-muncher so that the item's attributes are not restricted to be in a specific order. Multiple `#[project]`/`#[project_ref]`/`#[project_replace]` attributes will fail to compile unless there is a `#[project]`/`#[project_ref]`/`#[project_replace]` attribute in scope.