### PR TITLE
[WIP] refactors visibility parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1404,6 +1404,7 @@ macro_rules! __pin_project_internal {
     // =============================================================================================
     // Parses input and determines visibility
 
+    // parsing proj_mut_ident
     (
         []
         [$($proj_ref_ident:ident)?]
@@ -1422,6 +1423,7 @@ macro_rules! __pin_project_internal {
         }
     };
 
+    // parsing proj_ref_ident
     {
         [$($proj_mut_ident:ident)?]
         []
@@ -1440,6 +1442,7 @@ macro_rules! __pin_project_internal {
         }
     };
 
+    // parsing proj_replace_ident
     {
         [$($proj_mut_ident:ident)?]
         [$($proj_ref_ident:ident)?]
@@ -1458,6 +1461,8 @@ macro_rules! __pin_project_internal {
         }
     };
 
+    // this is actually part of a recurssive step,
+    // there could be more to parse
     {
         [$($proj_mut_ident:ident)?]
         [$($proj_ref_ident:ident)?]
@@ -1476,82 +1481,51 @@ macro_rules! __pin_project_internal {
         }
     };
 
-    // struct
-    (
+    // now determine visibility
+    // if public, downgrade
+    {
         [$($proj_mut_ident:ident)?]
         [$($proj_ref_ident:ident)?]
         [$($proj_replace_ident:ident)?]
         [$($attrs:tt)*]
-
-        pub struct $ident:ident $(<
-            $( $lifetime:lifetime $(: $lifetime_bound:lifetime)? ),* $(,)?
-            $( $generics:ident
-                $(: $generics_bound:path)?
-                $(: ?$generics_unsized_bound:path)?
-                $(: $generics_lifetime_bound:lifetime)?
-                $(= $generics_default:ty)?
-            ),* $(,)?
-        >)?
-        $(where
-            $( $where_clause_ty:ty
-                $(: $where_clause_bound:path)?
-                $(: ?$where_clause_unsized_bound:path)?
-                $(: $where_clause_lifetime_bound:lifetime)?
-            ),* $(,)?
-        )?
-        {
-            $(
-                $(#[$pin:ident])?
-                $field_vis:vis $field:ident: $field_ty:ty
-            ),+ $(,)?
-        }
-        $(impl $($pinned_drop:tt)*)?
-    ) => {
-        $crate::__pin_project_internal! { @struct=>internal;
+        pub $struct_ty_ident:ident $ident:ident
+        $($tt:tt)*
+    } => {
+        $crate::__pin_project_internal! {@$struct_ty_ident=>parse;
             [$($proj_mut_ident)?]
             [$($proj_ref_ident)?]
             [$($proj_replace_ident)?]
-            [pub(crate)]
-            [$($attrs)* pub struct $ident]
-            [$(<
-                $( $lifetime $(: $lifetime_bound)? ,)*
-                $( $generics
-                    $(: $generics_bound)?
-                    $(: ?$generics_unsized_bound)?
-                    $(: $generics_lifetime_bound)?
-                    $(= $generics_default)?
-                ),*
-            >)?]
-            [$(
-                $( $lifetime $(: $lifetime_bound)? ,)*
-                $( $generics
-                    $(: $generics_bound)?
-                    $(: ?$generics_unsized_bound)?
-                    $(: $generics_lifetime_bound)?
-                ),*
-            )?]
-            [$( $( $lifetime ,)* $( $generics ),* )?]
-            [$(where $( $where_clause_ty
-                $(: $where_clause_bound)?
-                $(: ?$where_clause_unsized_bound)?
-                $(: $where_clause_lifetime_bound)?
-            ),* )?]
-            {
-                $(
-                    $(#[$pin])?
-                    $field_vis $field: $field_ty
-                ),+
-            }
-            $(impl $($pinned_drop)*)?
+            [$($attrs)*]
+            [pub $struct_ty_ident $ident pub(crate)]
+            $($tt)*
         }
     };
-    (
+    {
         [$($proj_mut_ident:ident)?]
         [$($proj_ref_ident:ident)?]
         [$($proj_replace_ident:ident)?]
         [$($attrs:tt)*]
-
-        $vis:vis struct $ident:ident $(<
+        $vis:vis $struct_ty_ident:ident $ident:ident
+        $($tt:tt)*
+    } => {
+        $crate::__pin_project_internal! {@$struct_ty_ident=>parse;
+            [$($proj_mut_ident)?]
+            [$($proj_ref_ident)?]
+            [$($proj_replace_ident)?]
+            [$($attrs)*]
+            [$vis $struct_ty_ident $ident $vis]
+            $($tt)*
+        }
+    };
+    /////////////////////////
+    // PARSE FUNCTION
+    (@struct=>parse;
+        [$($proj_mut_ident:ident)?]
+        [$($proj_ref_ident:ident)?]
+        [$($proj_replace_ident:ident)?]
+        [$($attrs:tt)*]
+        [$vis:vis struct $ident:ident $proj_ty_vis:vis]
+        $(<
             $( $lifetime:lifetime $(: $lifetime_bound:lifetime)? ),* $(,)?
             $( $generics:ident
                 $(: $generics_bound:path)?
@@ -1579,7 +1553,7 @@ macro_rules! __pin_project_internal {
             [$($proj_mut_ident)?]
             [$($proj_ref_ident)?]
             [$($proj_replace_ident)?]
-            [$vis]
+            [$proj_ty_vis]
             [$($attrs)* $vis struct $ident]
             [$(<
                 $( $lifetime $(: $lifetime_bound)? ,)*
@@ -1613,14 +1587,13 @@ macro_rules! __pin_project_internal {
             $(impl $($pinned_drop)*)?
         }
     };
-    // enum
-    (
+    (@enum=>parse;
         [$($proj_mut_ident:ident)?]
         [$($proj_ref_ident:ident)?]
         [$($proj_replace_ident:ident)?]
         [$($attrs:tt)*]
-
-        pub enum $ident:ident $(<
+        [$vis:vis enum $ident:ident $proj_ty_vis:vis]
+        $(<
             $( $lifetime:lifetime $(: $lifetime_bound:lifetime)? ),* $(,)?
             $( $generics:ident
                 $(: $generics_bound:path)?
@@ -1653,85 +1626,7 @@ macro_rules! __pin_project_internal {
             [$($proj_mut_ident)?]
             [$($proj_ref_ident)?]
             [$($proj_replace_ident)?]
-            [pub(crate)]
-            [$($attrs)* pub enum $ident]
-            [$(<
-                $( $lifetime $(: $lifetime_bound)? ,)*
-                $( $generics
-                    $(: $generics_bound)?
-                    $(: ?$generics_unsized_bound)?
-                    $(: $generics_lifetime_bound)?
-                    $(= $generics_default)?
-                ),*
-            >)?]
-            [$(
-                $( $lifetime $(: $lifetime_bound)? ,)*
-                $( $generics
-                    $(: $generics_bound)?
-                    $(: ?$generics_unsized_bound)?
-                    $(: $generics_lifetime_bound)?
-                ),*
-            )?]
-            [$( $( $lifetime ,)* $( $generics ),* )?]
-            [$(where $( $where_clause_ty
-                $(: $where_clause_bound)?
-                $(: ?$where_clause_unsized_bound)?
-                $(: $where_clause_lifetime_bound)?
-            ),* )?]
-            {
-                $(
-                    $(#[$variant_attrs])*
-                    $variant $({
-                        $(
-                            $(#[$pin])?
-                            $field: $field_ty
-                        ),+
-                    })?
-                ),+
-            }
-            $(impl $($pinned_drop)*)?
-        }
-    };
-    (
-        [$($proj_mut_ident:ident)?]
-        [$($proj_ref_ident:ident)?]
-        [$($proj_replace_ident:ident)?]
-        [$($attrs:tt)*]
-
-        $vis:vis enum $ident:ident $(<
-            $( $lifetime:lifetime $(: $lifetime_bound:lifetime)? ),* $(,)?
-            $( $generics:ident
-                $(: $generics_bound:path)?
-                $(: ?$generics_unsized_bound:path)?
-                $(: $generics_lifetime_bound:lifetime)?
-                $(= $generics_default:ty)?
-            ),* $(,)?
-        >)?
-        $(where
-            $( $where_clause_ty:ty
-                $(: $where_clause_bound:path)?
-                $(: ?$where_clause_unsized_bound:path)?
-                $(: $where_clause_lifetime_bound:lifetime)?
-            ),* $(,)?
-        )?
-        {
-            $(
-                $(#[$variant_attrs:meta])*
-                $variant:ident $({
-                    $(
-                        $(#[$pin:ident])?
-                        $field:ident: $field_ty:ty
-                    ),+ $(,)?
-                })?
-            ),+ $(,)?
-        }
-        $(impl $($pinned_drop:tt)*)?
-    ) => {
-        $crate::__pin_project_internal! { @enum=>internal;
-            [$($proj_mut_ident)?]
-            [$($proj_ref_ident)?]
-            [$($proj_replace_ident)?]
-            [$vis]
+            [$proj_ty_vis]
             [$($attrs)* $vis enum $ident]
             [$(<
                 $( $lifetime $(: $lifetime_bound)? ,)*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,8 +318,8 @@ macro_rules! __pin_project_internal {
         [$($proj_replace_ident:ident)?]
         [$proj_vis:vis]
         [$(#[$attrs:meta])* $vis:vis struct $ident:ident]
-        [$($def_generics:tt)*]
-        [$($impl_generics:tt)*] [$($ty_generics:tt)*] [$(where $($where_clause:tt)*)?]
+        [$($def_generics:tt)*] [$($impl_generics:tt)*] [$($ty_generics:tt)*]
+        [$(where $($where_clause:tt)*)?]
         {
             $(
                 $(#[$pin:ident])?
@@ -524,8 +524,8 @@ macro_rules! __pin_project_internal {
         [$($proj_replace_ident:ident)?]
         [$proj_vis:vis]
         [$(#[$attrs:meta])* $vis:vis enum $ident:ident]
-        [$($def_generics:tt)*]
-        [$($impl_generics:tt)*] [$($ty_generics:tt)*] [$(where $($where_clause:tt)*)?]
+        [$($def_generics:tt)*] [$($impl_generics:tt)*] [$($ty_generics:tt)*]
+        [$(where $($where_clause:tt)*)?]
         {
             $(
                 $(#[$variant_attrs:meta])*
@@ -1491,7 +1491,7 @@ macro_rules! __pin_project_internal {
         pub $struct_ty_ident:ident $ident:ident
         $($tt:tt)*
     } => {
-        $crate::__pin_project_internal! {@$struct_ty_ident=>parse;
+        $crate::__pin_project_internal! {@generics;
             [$($proj_mut_ident)?]
             [$($proj_ref_ident)?]
             [$($proj_replace_ident)?]
@@ -1523,25 +1523,6 @@ macro_rules! __pin_project_internal {
         [$($proj_replace_ident:ident)?]
         [$($attrs:tt)*]
         [$vis:vis $struct_ty_ident:ident $ident:ident $proj_ty_vis:vis]
-        $($tt:tt)*
-    ) => {
-        $crate::__pin_project_internal! {@$struct_ty_ident=>parse;
-            [$($proj_mut_ident)?]
-            [$($proj_ref_ident)?]
-            [$($proj_replace_ident)?]
-            [$($attrs)*]
-            [$vis $struct_ty_ident $ident $vis]
-            $($tt)*
-        }
-    };
-    /////////////////////////
-    // PARSE FUNCTION
-    (@struct=>parse;
-        [$($proj_mut_ident:ident)?]
-        [$($proj_ref_ident:ident)?]
-        [$($proj_replace_ident:ident)?]
-        [$($attrs:tt)*]
-        [$vis:vis struct $ident:ident $proj_ty_vis:vis]
         $(<
             $( $lifetime:lifetime $(: $lifetime_bound:lifetime)? ),* $(,)?
             $( $generics:ident
@@ -1558,20 +1539,19 @@ macro_rules! __pin_project_internal {
                 $(: $where_clause_lifetime_bound:lifetime)?
             ),* $(,)?
         )?
+        // for some reason these brackets prevent me from forwarding the entire token tree
+        // so i have to deconstract and pass
         {
-            $(
-                $(#[$pin:ident])?
-                $field_vis:vis $field:ident: $field_ty:ty
-            ),+ $(,)?
+            $($tt:tt)*
         }
         $(impl $($pinned_drop:tt)*)?
     ) => {
-        $crate::__pin_project_internal! { @struct=>internal;
+        $crate::__pin_project_internal! {@$struct_ty_ident=>parse;
             [$($proj_mut_ident)?]
             [$($proj_ref_ident)?]
             [$($proj_replace_ident)?]
-            [$proj_ty_vis]
-            [$($attrs)* $vis struct $ident]
+            [$($attrs)*]
+            [$vis $struct_ty_ident $ident $vis]
             [$(<
                 $( $lifetime $(: $lifetime_bound)? ,)*
                 $( $generics
@@ -1596,6 +1576,38 @@ macro_rules! __pin_project_internal {
                 $(: $where_clause_lifetime_bound)?
             ),* )?]
             {
+                $($tt)*
+            }
+            $(impl $($pinned_drop)*)?
+        }
+    };
+    /////////////////////////
+    // PARSE FUNCTION
+    (@struct=>parse;
+        [$($proj_mut_ident:ident)?]
+        [$($proj_ref_ident:ident)?]
+        [$($proj_replace_ident:ident)?]
+        [$($attrs:tt)*]
+        [$vis:vis struct $ident:ident $proj_ty_vis:vis]
+        [$($def_generics:tt)*] [$($impl_generics:tt)*] [$($ty_generics:tt)*]
+        [$(where $($where_clause:tt)*)?]
+        {
+            $(
+                $(#[$pin:ident])?
+                $field_vis:vis $field:ident: $field_ty:ty
+            ),+ $(,)?
+        }
+        $(impl $($pinned_drop:tt)*)?
+    ) => {
+        $crate::__pin_project_internal! { @struct=>internal;
+            [$($proj_mut_ident)?]
+            [$($proj_ref_ident)?]
+            [$($proj_replace_ident)?]
+            [$proj_ty_vis]
+            [$($attrs)* $vis struct $ident]
+            [$($def_generics)*] [$($impl_generics)*] [$($ty_generics)*]
+            [$(where $($where_clause)*)?]
+            {
                 $(
                     $(#[$pin])?
                     $field_vis $field: $field_ty
@@ -1610,22 +1622,8 @@ macro_rules! __pin_project_internal {
         [$($proj_replace_ident:ident)?]
         [$($attrs:tt)*]
         [$vis:vis enum $ident:ident $proj_ty_vis:vis]
-        $(<
-            $( $lifetime:lifetime $(: $lifetime_bound:lifetime)? ),* $(,)?
-            $( $generics:ident
-                $(: $generics_bound:path)?
-                $(: ?$generics_unsized_bound:path)?
-                $(: $generics_lifetime_bound:lifetime)?
-                $(= $generics_default:ty)?
-            ),* $(,)?
-        >)?
-        $(where
-            $( $where_clause_ty:ty
-                $(: $where_clause_bound:path)?
-                $(: ?$where_clause_unsized_bound:path)?
-                $(: $where_clause_lifetime_bound:lifetime)?
-            ),* $(,)?
-        )?
+        [$($def_generics:tt)*] [$($impl_generics:tt)*] [$($ty_generics:tt)*]
+        [$(where $($where_clause:tt)*)?]
         {
             $(
                 $(#[$variant_attrs:meta])*
@@ -1645,29 +1643,8 @@ macro_rules! __pin_project_internal {
             [$($proj_replace_ident)?]
             [$proj_ty_vis]
             [$($attrs)* $vis enum $ident]
-            [$(<
-                $( $lifetime $(: $lifetime_bound)? ,)*
-                $( $generics
-                    $(: $generics_bound)?
-                    $(: ?$generics_unsized_bound)?
-                    $(: $generics_lifetime_bound)?
-                    $(= $generics_default)?
-                ),*
-            >)?]
-            [$(
-                $( $lifetime $(: $lifetime_bound)? ,)*
-                $( $generics
-                    $(: $generics_bound)?
-                    $(: ?$generics_unsized_bound)?
-                    $(: $generics_lifetime_bound)?
-                ),*
-            )?]
-            [$( $( $lifetime ,)* $( $generics ),* )?]
-            [$(where $( $where_clause_ty
-                $(: $where_clause_bound)?
-                $(: ?$where_clause_unsized_bound)?
-                $(: $where_clause_lifetime_bound)?
-            ),* )?]
+            [$($def_generics)*] [$($impl_generics)*] [$($ty_generics)*]
+            [$(where $($where_clause)*)?]
             {
                 $(
                     $(#[$variant_attrs])*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1482,7 +1482,7 @@ macro_rules! __pin_project_internal {
     };
 
     // now determine visibility
-    // if public, downgrade
+    // if public, downgrade to pub(crate)
     {
         [$($proj_mut_ident:ident)?]
         [$($proj_ref_ident:ident)?]
@@ -1500,6 +1500,7 @@ macro_rules! __pin_project_internal {
             $($tt)*
         }
     };
+    // if not public, the projection gets the same visibility
     {
         [$($proj_mut_ident:ident)?]
         [$($proj_ref_ident:ident)?]
@@ -1539,10 +1540,8 @@ macro_rules! __pin_project_internal {
                 $(: $where_clause_lifetime_bound:lifetime)?
             ),* $(,)?
         )?
-        // for some reason these brackets prevent me from forwarding the entire token tree
-        // so I have to deconstruct and pass
         {
-            $($tt:tt)*
+            $($tt:tt)+
         }
         $(impl $($pinned_drop:tt)*)?
     ) => {
@@ -1576,7 +1575,7 @@ macro_rules! __pin_project_internal {
                 $(: $where_clause_lifetime_bound)?
             ),* )?]
             {
-                $($tt)*
+                $($tt)+
             }
             $(impl $($pinned_drop)*)?
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1491,7 +1491,7 @@ macro_rules! __pin_project_internal {
         pub $struct_ty_ident:ident $ident:ident
         $($tt:tt)*
     } => {
-        $crate::__pin_project_internal! {@generics;
+        $crate::__pin_project_internal! {
             [$($proj_mut_ident)?]
             [$($proj_ref_ident)?]
             [$($proj_replace_ident)?]
@@ -1509,7 +1509,7 @@ macro_rules! __pin_project_internal {
         $vis:vis $struct_ty_ident:ident $ident:ident
         $($tt:tt)*
     } => {
-        $crate::__pin_project_internal! {@generics;
+        $crate::__pin_project_internal! {
             [$($proj_mut_ident)?]
             [$($proj_ref_ident)?]
             [$($proj_replace_ident)?]
@@ -1518,7 +1518,7 @@ macro_rules! __pin_project_internal {
             $($tt)*
         }
     };
-    (@generics;
+    (
         [$($proj_mut_ident:ident)?]
         [$($proj_ref_ident:ident)?]
         [$($proj_replace_ident:ident)?]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1551,7 +1551,7 @@ macro_rules! __pin_project_internal {
             [$($proj_ref_ident)?]
             [$($proj_replace_ident)?]
             [$($attrs)*]
-            [$vis $struct_ty_ident $ident $vis]
+            [$vis $struct_ty_ident $ident $proj_ty_vis]
             [$(<
                 $( $lifetime $(: $lifetime_bound)? ,)*
                 $( $generics

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1461,7 +1461,7 @@ macro_rules! __pin_project_internal {
         }
     };
 
-    // this is actually part of a recurssive step,
+    // this is actually part of a recursive step,
     // there could be more to parse
     {
         [$($proj_mut_ident:ident)?]
@@ -1540,7 +1540,7 @@ macro_rules! __pin_project_internal {
             ),* $(,)?
         )?
         // for some reason these brackets prevent me from forwarding the entire token tree
-        // so i have to deconstract and pass
+        // so I have to deconstruct and pass
         {
             $($tt:tt)*
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1508,6 +1508,23 @@ macro_rules! __pin_project_internal {
         $vis:vis $struct_ty_ident:ident $ident:ident
         $($tt:tt)*
     } => {
+        $crate::__pin_project_internal! {@generics;
+            [$($proj_mut_ident)?]
+            [$($proj_ref_ident)?]
+            [$($proj_replace_ident)?]
+            [$($attrs)*]
+            [$vis $struct_ty_ident $ident $vis]
+            $($tt)*
+        }
+    };
+    (@generics;
+        [$($proj_mut_ident:ident)?]
+        [$($proj_ref_ident:ident)?]
+        [$($proj_replace_ident:ident)?]
+        [$($attrs:tt)*]
+        [$vis:vis $struct_ty_ident:ident $ident:ident $proj_ty_vis:vis]
+        $($tt:tt)*
+    ) => {
         $crate::__pin_project_internal! {@$struct_ty_ident=>parse;
             [$($proj_mut_ident)?]
             [$($proj_ref_ident)?]


### PR DESCRIPTION
Working towards handling newtype-variants on enums, slimming down what will need to change for that.

Before, visibility parsing / downgrade logic was implemented separately for structs and enums. Since this was done at the same stage as lifetime / field / variant parsing, the result was a decent amount of duplicated code.

Now, visibility is parsed first before dispatching to the separate struct/enum parsing.