### PR TITLE
Inline project methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -936,6 +936,7 @@ macro_rules! __pin_project_struct_make_proj_method {
             ),+
         }
     ) => {
+        #[inline]
         $proj_vis fn $method_ident<'__pin>(
             self: $crate::__private::Pin<&'__pin $($mut)? Self>,
         ) -> $proj_ty_ident <'__pin, $($ty_generics)*> {
@@ -969,6 +970,7 @@ macro_rules! __pin_project_struct_make_proj_replace_method {
             ),+
         }
     ) => {
+        #[inline]
         $proj_vis fn project_replace(
             self: $crate::__private::Pin<&mut Self>,
             replacement: Self,
@@ -1016,6 +1018,7 @@ macro_rules! __pin_project_enum_make_proj_method {
             ),+
         }
     ) => {
+        #[inline]
         $proj_vis fn $method_ident<'__pin>(
             self: $crate::__private::Pin<&'__pin $($mut)? Self>,
         ) -> $proj_ty_ident <'__pin, $($ty_generics)*> {
@@ -1059,6 +1062,7 @@ macro_rules! __pin_project_enum_make_proj_replace_method {
             ),+
         }
     ) => {
+        #[inline]
         $proj_vis fn project_replace(
             self: $crate::__private::Pin<&mut Self>,
             replacement: Self,

--- a/tests/expand/default/enum.expanded.rs
+++ b/tests/expand/default/enum.expanded.rs
@@ -51,6 +51,7 @@ enum EnumProjReplace<T, U> {
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {
+        #[inline]
         fn project<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,
         ) -> EnumProj<'__pin, T, U> {
@@ -68,6 +69,7 @@ const _: () = {
                 }
             }
         }
+        #[inline]
         fn project_ref<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin Self>,
         ) -> EnumProjRef<'__pin, T, U> {
@@ -85,6 +87,7 @@ const _: () = {
                 }
             }
         }
+        #[inline]
         fn project_replace(
             self: ::pin_project_lite::__private::Pin<&mut Self>,
             replacement: Self,

--- a/tests/expand/default/struct.expanded.rs
+++ b/tests/expand/default/struct.expanded.rs
@@ -38,6 +38,7 @@ const _: () = {
         unpinned: &'__pin (U),
     }
     impl<T, U> Struct<T, U> {
+        #[inline]
         fn project<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,
         ) -> Projection<'__pin, T, U> {
@@ -49,6 +50,7 @@ const _: () = {
                 }
             }
         }
+        #[inline]
         fn project_ref<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin Self>,
         ) -> ProjectionRef<'__pin, T, U> {

--- a/tests/expand/multifields/enum.expanded.rs
+++ b/tests/expand/multifields/enum.expanded.rs
@@ -22,6 +22,7 @@ enum EnumProjReplace<T, U> {
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {
+        #[inline]
         fn project_replace(
             self: ::pin_project_lite::__private::Pin<&mut Self>,
             replacement: Self,

--- a/tests/expand/multifields/struct.expanded.rs
+++ b/tests/expand/multifields/struct.expanded.rs
@@ -55,6 +55,7 @@ const _: () = {
         unpinned2: &'__pin (U),
     }
     impl<T, U> Struct<T, U> {
+        #[inline]
         fn project<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,
         ) -> Projection<'__pin, T, U> {
@@ -69,6 +70,7 @@ const _: () = {
                 }
             }
         }
+        #[inline]
         fn project_ref<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin Self>,
         ) -> ProjectionRef<'__pin, T, U> {
@@ -82,6 +84,7 @@ const _: () = {
                 }
             }
         }
+        #[inline]
         fn project_replace(
             self: ::pin_project_lite::__private::Pin<&mut Self>,
             replacement: Self,

--- a/tests/expand/naming/enum-all.expanded.rs
+++ b/tests/expand/naming/enum-all.expanded.rs
@@ -51,6 +51,7 @@ enum EnumProjReplace<T, U> {
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {
+        #[inline]
         fn project<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,
         ) -> EnumProj<'__pin, T, U> {
@@ -68,6 +69,7 @@ const _: () = {
                 }
             }
         }
+        #[inline]
         fn project_ref<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin Self>,
         ) -> EnumProjRef<'__pin, T, U> {
@@ -85,6 +87,7 @@ const _: () = {
                 }
             }
         }
+        #[inline]
         fn project_replace(
             self: ::pin_project_lite::__private::Pin<&mut Self>,
             replacement: Self,

--- a/tests/expand/naming/enum-mut.expanded.rs
+++ b/tests/expand/naming/enum-mut.expanded.rs
@@ -25,6 +25,7 @@ where
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {
+        #[inline]
         fn project<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,
         ) -> EnumProj<'__pin, T, U> {

--- a/tests/expand/naming/enum-ref.expanded.rs
+++ b/tests/expand/naming/enum-ref.expanded.rs
@@ -25,6 +25,7 @@ where
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {
+        #[inline]
         fn project_ref<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin Self>,
         ) -> EnumProjRef<'__pin, T, U> {

--- a/tests/expand/naming/struct-all.expanded.rs
+++ b/tests/expand/naming/struct-all.expanded.rs
@@ -47,6 +47,7 @@ struct StructProjReplace<T, U> {
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Struct<T, U> {
+        #[inline]
         fn project<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,
         ) -> StructProj<'__pin, T, U> {
@@ -58,6 +59,7 @@ const _: () = {
                 }
             }
         }
+        #[inline]
         fn project_ref<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin Self>,
         ) -> StructProjRef<'__pin, T, U> {
@@ -69,6 +71,7 @@ const _: () = {
                 }
             }
         }
+        #[inline]
         fn project_replace(
             self: ::pin_project_lite::__private::Pin<&mut Self>,
             replacement: Self,

--- a/tests/expand/naming/struct-mut.expanded.rs
+++ b/tests/expand/naming/struct-mut.expanded.rs
@@ -38,6 +38,7 @@ const _: () = {
         unpinned: &'__pin (U),
     }
     impl<T, U> Struct<T, U> {
+        #[inline]
         fn project<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,
         ) -> StructProj<'__pin, T, U> {
@@ -49,6 +50,7 @@ const _: () = {
                 }
             }
         }
+        #[inline]
         fn project_ref<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin Self>,
         ) -> ProjectionRef<'__pin, T, U> {

--- a/tests/expand/naming/struct-none.expanded.rs
+++ b/tests/expand/naming/struct-none.expanded.rs
@@ -38,6 +38,7 @@ const _: () = {
         unpinned: &'__pin (U),
     }
     impl<T, U> Struct<T, U> {
+        #[inline]
         fn project<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,
         ) -> Projection<'__pin, T, U> {
@@ -49,6 +50,7 @@ const _: () = {
                 }
             }
         }
+        #[inline]
         fn project_ref<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin Self>,
         ) -> ProjectionRef<'__pin, T, U> {

--- a/tests/expand/naming/struct-ref.expanded.rs
+++ b/tests/expand/naming/struct-ref.expanded.rs
@@ -38,6 +38,7 @@ const _: () = {
         unpinned: &'__pin mut (U),
     }
     impl<T, U> Struct<T, U> {
+        #[inline]
         fn project<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,
         ) -> Projection<'__pin, T, U> {
@@ -49,6 +50,7 @@ const _: () = {
                 }
             }
         }
+        #[inline]
         fn project_ref<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin Self>,
         ) -> StructProjRef<'__pin, T, U> {

--- a/tests/expand/pinned_drop/enum.expanded.rs
+++ b/tests/expand/pinned_drop/enum.expanded.rs
@@ -43,6 +43,7 @@ where
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {
+        #[inline]
         fn project<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,
         ) -> EnumProj<'__pin, T, U> {
@@ -60,6 +61,7 @@ const _: () = {
                 }
             }
         }
+        #[inline]
         fn project_ref<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin Self>,
         ) -> EnumProjRef<'__pin, T, U> {

--- a/tests/expand/pinned_drop/struct.expanded.rs
+++ b/tests/expand/pinned_drop/struct.expanded.rs
@@ -39,6 +39,7 @@ const _: () = {
         unpinned: &'__pin (U),
     }
     impl<T, U> Struct<T, U> {
+        #[inline]
         fn project<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,
         ) -> Projection<'__pin, T, U> {
@@ -50,6 +51,7 @@ const _: () = {
                 }
             }
         }
+        #[inline]
         fn project_ref<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin Self>,
         ) -> ProjectionRef<'__pin, T, U> {

--- a/tests/expand/pub/enum.expanded.rs
+++ b/tests/expand/pub/enum.expanded.rs
@@ -42,6 +42,7 @@ where
 #[allow(clippy::used_underscore_binding)]
 const _: () = {
     impl<T, U> Enum<T, U> {
+        #[inline]
         pub(crate) fn project<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,
         ) -> EnumProj<'__pin, T, U> {
@@ -59,6 +60,7 @@ const _: () = {
                 }
             }
         }
+        #[inline]
         pub(crate) fn project_ref<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin Self>,
         ) -> EnumProjRef<'__pin, T, U> {

--- a/tests/expand/pub/struct.expanded.rs
+++ b/tests/expand/pub/struct.expanded.rs
@@ -38,6 +38,7 @@ const _: () = {
         pub unpinned: &'__pin (U),
     }
     impl<T, U> Struct<T, U> {
+        #[inline]
         pub(crate) fn project<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,
         ) -> Projection<'__pin, T, U> {
@@ -49,6 +50,7 @@ const _: () = {
                 }
             }
         }
+        #[inline]
         pub(crate) fn project_ref<'__pin>(
             self: ::pin_project_lite::__private::Pin<&'__pin Self>,
         ) -> ProjectionRef<'__pin, T, U> {


### PR DESCRIPTION
Sometime these methods are not inline under `opt-level=z` compile option, forcing inlining could be beneficial for performance and binary size.