### PR TITLE
Add support for `#[project(!Unpin)]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,8 +295,22 @@ pin-project supports this.
 ///
 /// # `!Unpin`
 ///
-/// If you want to ensure that [`Unpin`] is not implemented, use `#[pin]`
-/// attribute for a [`PhantomPinned`] field.
+/// If you want to make sure `Unpin` is not implemented, use the `#[project(!Unpin)]`
+/// attribute.
+///
+/// ```
+/// use pin_project_lite::pin_project;
+///
+/// pin_project! {
+///      #[project(!Unpin)]
+///      struct Struct<T> {
+///          #[pin]
+///          field: T,
+///      }
+/// }
+/// ```
+///
+/// This is equivalent to using `#[pin]` attribute for a [`PhantomPinned`] field.
 ///
 /// ```rust
 /// use std::marker::PhantomPinned;
@@ -306,13 +320,14 @@ pin-project supports this.
 /// pin_project! {
 ///     struct Struct<T> {
 ///         field: T,
-///         #[pin] // <------ This `#[pin]` is required to make `Struct` to `!Unpin`.
+///         #[pin]
 ///         _pin: PhantomPinned,
 ///     }
 /// }
 /// ```
 ///
-/// Note that using [`PhantomPinned`] without `#[pin]` attribute has no effect.
+/// Note that using [`PhantomPinned`] without `#[pin]` or `#[project(!Unpin)]`
+/// attribute has no effect.
 ///
 /// [`PhantomPinned`]: core::marker::PhantomPinned
 /// [`Pin::as_mut`]: core::pin::Pin::as_mut

--- a/tests/expand/not_unpin/enum.expanded.rs
+++ b/tests/expand/not_unpin/enum.expanded.rs
@@ -1,0 +1,95 @@
+use pin_project_lite::pin_project;
+enum Enum<T, U> {
+    Struct { pinned: T, unpinned: U },
+    Unit,
+}
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::unknown_clippy_lints)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::ref_option_ref)]
+#[allow(clippy::type_repetition_in_bounds)]
+enum EnumProj<'__pin, T, U>
+where
+    Enum<T, U>: '__pin,
+{
+    Struct {
+        pinned: ::pin_project_lite::__private::Pin<&'__pin mut (T)>,
+        unpinned: &'__pin mut (U),
+    },
+    Unit,
+}
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::unknown_clippy_lints)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::ref_option_ref)]
+#[allow(clippy::type_repetition_in_bounds)]
+enum EnumProjRef<'__pin, T, U>
+where
+    Enum<T, U>: '__pin,
+{
+    Struct {
+        pinned: ::pin_project_lite::__private::Pin<&'__pin (T)>,
+        unpinned: &'__pin (U),
+    },
+    Unit,
+}
+#[allow(single_use_lifetimes)]
+#[allow(clippy::unknown_clippy_lints)]
+#[allow(clippy::used_underscore_binding)]
+const _: () = {
+    impl<T, U> Enum<T, U> {
+        #[inline]
+        fn project<'__pin>(
+            self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,
+        ) -> EnumProj<'__pin, T, U> {
+            unsafe {
+                match self.get_unchecked_mut() {
+                    Self::Struct { pinned, unpinned } => {
+                        EnumProj::Struct {
+                            pinned: ::pin_project_lite::__private::Pin::new_unchecked(
+                                pinned,
+                            ),
+                            unpinned: unpinned,
+                        }
+                    }
+                    Self::Unit => EnumProj::Unit,
+                }
+            }
+        }
+        #[inline]
+        fn project_ref<'__pin>(
+            self: ::pin_project_lite::__private::Pin<&'__pin Self>,
+        ) -> EnumProjRef<'__pin, T, U> {
+            unsafe {
+                match self.get_ref() {
+                    Self::Struct { pinned, unpinned } => {
+                        EnumProjRef::Struct {
+                            pinned: ::pin_project_lite::__private::Pin::new_unchecked(
+                                pinned,
+                            ),
+                            unpinned: unpinned,
+                        }
+                    }
+                    Self::Unit => EnumProjRef::Unit,
+                }
+            }
+        }
+    }
+    #[doc(hidden)]
+    impl<'__pin, T, U> ::pin_project_lite::__private::Unpin for Enum<T, U>
+    where
+        (
+            ::core::marker::PhantomData<&'__pin ()>,
+            ::core::marker::PhantomPinned,
+        ): ::pin_project_lite::__private::Unpin,
+    {}
+    trait MustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::pin_project_lite::__private::Drop> MustNotImplDrop for T {}
+    impl<T, U> MustNotImplDrop for Enum<T, U> {}
+};
+fn main() {}

--- a/tests/expand/not_unpin/enum.rs
+++ b/tests/expand/not_unpin/enum.rs
@@ -1,0 +1,17 @@
+use pin_project_lite::pin_project;
+
+pin_project! {
+    #[project(!Unpin)]
+    #[project = EnumProj]
+    #[project_ref = EnumProjRef]
+    enum Enum<T, U> {
+        Struct {
+            #[pin]
+            pinned: T,
+            unpinned: U,
+        },
+        Unit,
+    }
+}
+
+fn main() {}

--- a/tests/expand/not_unpin/struct.expanded.rs
+++ b/tests/expand/not_unpin/struct.expanded.rs
@@ -1,0 +1,84 @@
+use pin_project_lite::pin_project;
+struct Struct<T, U> {
+    pinned: T,
+    unpinned: U,
+}
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::unknown_clippy_lints)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::ref_option_ref)]
+#[allow(clippy::type_repetition_in_bounds)]
+struct StructProj<'__pin, T, U>
+where
+    Struct<T, U>: '__pin,
+{
+    pinned: ::pin_project_lite::__private::Pin<&'__pin mut (T)>,
+    unpinned: &'__pin mut (U),
+}
+#[allow(dead_code)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::unknown_clippy_lints)]
+#[allow(clippy::mut_mut)]
+#[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::ref_option_ref)]
+#[allow(clippy::type_repetition_in_bounds)]
+struct StructProjRef<'__pin, T, U>
+where
+    Struct<T, U>: '__pin,
+{
+    pinned: ::pin_project_lite::__private::Pin<&'__pin (T)>,
+    unpinned: &'__pin (U),
+}
+#[allow(explicit_outlives_requirements)]
+#[allow(single_use_lifetimes)]
+#[allow(clippy::unknown_clippy_lints)]
+#[allow(clippy::redundant_pub_crate)]
+#[allow(clippy::used_underscore_binding)]
+const _: () = {
+    impl<T, U> Struct<T, U> {
+        #[inline]
+        fn project<'__pin>(
+            self: ::pin_project_lite::__private::Pin<&'__pin mut Self>,
+        ) -> StructProj<'__pin, T, U> {
+            unsafe {
+                let Self { pinned, unpinned } = self.get_unchecked_mut();
+                StructProj {
+                    pinned: ::pin_project_lite::__private::Pin::new_unchecked(pinned),
+                    unpinned: unpinned,
+                }
+            }
+        }
+        #[inline]
+        fn project_ref<'__pin>(
+            self: ::pin_project_lite::__private::Pin<&'__pin Self>,
+        ) -> StructProjRef<'__pin, T, U> {
+            unsafe {
+                let Self { pinned, unpinned } = self.get_ref();
+                StructProjRef {
+                    pinned: ::pin_project_lite::__private::Pin::new_unchecked(pinned),
+                    unpinned: unpinned,
+                }
+            }
+        }
+    }
+    #[doc(hidden)]
+    impl<'__pin, T, U> ::pin_project_lite::__private::Unpin for Struct<T, U>
+    where
+        (
+            ::core::marker::PhantomData<&'__pin ()>,
+            ::core::marker::PhantomPinned,
+        ): ::pin_project_lite::__private::Unpin,
+    {}
+    trait MustNotImplDrop {}
+    #[allow(clippy::drop_bounds, drop_bounds)]
+    impl<T: ::pin_project_lite::__private::Drop> MustNotImplDrop for T {}
+    impl<T, U> MustNotImplDrop for Struct<T, U> {}
+    #[forbid(unaligned_references, safe_packed_borrows)]
+    fn __assert_not_repr_packed<T, U>(this: &Struct<T, U>) {
+        let _ = &this.pinned;
+        let _ = &this.unpinned;
+    }
+};
+fn main() {}

--- a/tests/expand/not_unpin/struct.rs
+++ b/tests/expand/not_unpin/struct.rs
@@ -1,0 +1,14 @@
+use pin_project_lite::pin_project;
+
+pin_project! {
+    #[project = StructProj]
+    #[project(!Unpin)]
+    #[project_ref = StructProjRef]
+    struct Struct<T, U> {
+        #[pin]
+        pinned: T,
+        unpinned: U,
+    }
+}
+
+fn main() {}

--- a/tests/lint.rs
+++ b/tests/lint.rs
@@ -70,6 +70,7 @@ pub mod box_pointers {
     pin_project! {
         #[project = EnumProj]
         #[project_ref = EnumProjRef]
+        #[project(!Unpin)]
         #[derive(Debug)]
         pub enum Enum {
             Struct {
@@ -101,6 +102,7 @@ pub mod explicit_outlives_requirements {
     pin_project! {
         #[project = EnumProj]
         #[project_ref = EnumProjRef]
+        #[project(!Unpin)]
         #[derive(Debug)]
         pub enum Enum<'a, T, U>
         where
@@ -123,6 +125,7 @@ pub mod variant_size_differences {
     pin_project! {
         #[project = EnumProj]
         #[project_ref = EnumProjRef]
+        #[project(!Unpin)]
         #[allow(missing_debug_implementations, missing_copy_implementations)] // https://github.com/rust-lang/rust/pull/74060
         #[allow(variant_size_differences)] // for the type itself
         #[allow(clippy::large_enum_variant)] // for the type itself
@@ -148,6 +151,7 @@ pub mod clippy_mut_mut {
     pin_project! {
         #[project = EnumProj]
         #[project_ref = EnumProjRef]
+        #[project(!Unpin)]
         #[derive(Debug)]
         pub enum Enum<'a, T, U> {
             Struct {
@@ -176,6 +180,7 @@ mod clippy_redundant_pub_crate {
     pin_project! {
         #[project = EnumProj]
         #[project_ref = EnumProjRef]
+        #[project(!Unpin)]
         #[derive(Debug)]
         pub enum Enum<T, U> {
             Struct {
@@ -207,6 +212,7 @@ pub mod clippy_type_repetition_in_bounds {
     pin_project! {
         #[project = EnumProj]
         #[project_ref = EnumProjRef]
+        #[project(!Unpin)]
         #[derive(Debug)]
         pub enum Enum<T, U>
         where
@@ -237,6 +243,7 @@ pub mod clippy_used_underscore_binding {
     pin_project! {
         #[project = EnumProj]
         #[project_ref = EnumProjRef]
+        #[project(!Unpin)]
         pub enum Enum<T, U> {
             Struct {
                 #[pin]
@@ -261,6 +268,7 @@ pub mod clippy_ref_option_ref {
     pin_project! {
         #[project = EnumProj]
         #[project_ref = EnumProjRef]
+        #[project(!Unpin)]
         pub enum Enum<'a> {
             Struct {
                 #[pin]

--- a/tests/proper_unpin.rs
+++ b/tests/proper_unpin.rs
@@ -47,6 +47,18 @@ pub mod default {
     assert_not_unpin!(Enum<PhantomPinned, PhantomPinned>);
 
     pin_project! {
+        #[project(!Unpin)]
+        enum NotUnpinEnum<T, U> {
+            V1 {
+                #[pin] f1: Inner<T>,
+                f2: U,
+            }
+        }
+    }
+
+    assert_not_unpin!(NotUnpinEnum<(), ()>);
+
+    pin_project! {
         struct TrivialBounds {
             #[pin]
             f: PhantomPinned,
@@ -64,4 +76,25 @@ pub mod default {
     }
 
     assert_unpin!(PinRef<'_, PhantomPinned, PhantomPinned>);
+
+    pin_project! {
+        #[project(!Unpin)]
+        struct NotUnpin<U> {
+            #[pin]
+            u: U
+        }
+    }
+
+    assert_not_unpin!(NotUnpin<()>);
+
+    pin_project! {
+        #[project(!Unpin)]
+        struct NotUnpinRef<'a, T, U> {
+            #[pin]
+            f1: &'a mut Inner<T>,
+            f2: U
+        }
+    }
+
+    assert_not_unpin!(NotUnpinRef<'_, (), ()>);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -616,6 +616,7 @@ fn attrs() {
     pin_project! {
         /// dox1
         #[derive(Clone)]
+        #[project(!Unpin)]
         #[project = Enum2Proj]
         #[project_ref = Enum2ProjRef]
         /// dox2

--- a/tests/ui/pin_project/conflict-unpin.rs
+++ b/tests/ui/pin_project/conflict-unpin.rs
@@ -37,4 +37,28 @@ pin_project! { //~ ERROR E0119
 // conflicting implementations
 impl<T: Unpin, U: Unpin> Unpin for Baz<T, U> {} // Conditional Unpin impl
 
+pin_project! { //~ ERROR E0119
+    #[project(!Unpin)]
+    struct Qux<T, U> {
+        #[pin]
+        future: T,
+        field: U,
+    }
+}
+
+// conflicting implementations
+impl<T, U> Unpin for Qux<T, U> {} // Non-conditional Unpin impl
+
+pin_project! { //~ ERROR E0119
+    #[project(!Unpin)]
+    struct Fred<T, U> {
+        #[pin]
+        future: T,
+        field: U,
+    }
+}
+
+// conflicting implementations
+impl<T: Unpin, U: Unpin> Unpin for Fred<T, U> {} // Conditional Unpin impl
+
 fn main() {}

--- a/tests/ui/pin_project/conflict-unpin.stderr
+++ b/tests/ui/pin_project/conflict-unpin.stderr
@@ -48,3 +48,37 @@ error[E0119]: conflicting implementations of trait `Unpin` for type `Baz<_, _>`
    |   -------------------------------------------- first implementation here
    |
    = note: this error originates in the macro `$crate::__pin_project_make_unpin_impl` which comes from the expansion of the macro `pin_project` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0119]: conflicting implementations of trait `Unpin` for type `Qux<_, _>`
+  --> tests/ui/pin_project/conflict-unpin.rs:40:1
+   |
+40 | / pin_project! { //~ ERROR E0119
+41 | |     #[project(!Unpin)]
+42 | |     struct Qux<T, U> {
+43 | |         #[pin]
+...  |
+46 | |     }
+47 | | }
+   | |_^ conflicting implementation for `Qux<_, _>`
+...
+50 |   impl<T, U> Unpin for Qux<T, U> {} // Non-conditional Unpin impl
+   |   ------------------------------ first implementation here
+   |
+   = note: this error originates in the macro `$crate::__pin_project_make_unpin_impl` which comes from the expansion of the macro `pin_project` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0119]: conflicting implementations of trait `Unpin` for type `Fred<_, _>`
+  --> tests/ui/pin_project/conflict-unpin.rs:52:1
+   |
+52 | / pin_project! { //~ ERROR E0119
+53 | |     #[project(!Unpin)]
+54 | |     struct Fred<T, U> {
+55 | |         #[pin]
+...  |
+58 | |     }
+59 | | }
+   | |_^ conflicting implementation for `Fred<_, _>`
+...
+62 |   impl<T: Unpin, U: Unpin> Unpin for Fred<T, U> {} // Conditional Unpin impl
+   |   --------------------------------------------- first implementation here
+   |
+   = note: this error originates in the macro `$crate::__pin_project_make_unpin_impl` which comes from the expansion of the macro `pin_project` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
This PR adds support to making types `!Unpin`.

Ex.:

```rust
pin_project! {
    #[project(!Unpin)]
    struct Foo<A, B> {
       #[pin]
       a: A,
       b: B,
    }
}
```

We also hide the documentation of the implementation that makes the type `!Unpin`, so it should not show in the rustdoc sidebar.

closes: #75